### PR TITLE
Enhance Postgres compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea/
+*.iml
+target/


### PR DESCRIPTION
Fixing https://github.com/openl-tablets/openl-tablets/issues/1

I does not expect it may reproduce any troubles for other RDBMS types, but test only on Postgress 9.4 locally.

Fix several issues on cache table creating on Postgre DB:
1) Postgress have several VARCHAR type, like "name" (for identifiers) which may be picked wrong. Add check on precision and ignore with 0.
2) Postgress table quoting make difference. If you do CRETAE TABLE "OPENL_JCR_CACHE" ... Then INSERT INTO openl_jcr_cache will failed!
If it created in quotes then name became case sensitive!
As solution try obtain such information in runtime from JDBC driver metadata.
3) idColumnType was NULL what lead on error in cache instatioation. Also take from meta.
4) In org.openl.rules.repository.factories.DBRepositoryFactory#determineDBDataTypes Postgress (9.4) dos not return anything with Types.LONGVARBINARY.
Apply fallback to VARBINARY or BINARY (but still prefer LONGVARBINARY).
5) Postgress use not integer type for TIMESTAMP. Introduce search of TIMESTAMP_WITH_TIMEZONE or TIMESTAMP. Leave fallback to bigintType.