### PR TITLE
fixed awkward wording in error messages

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/test/run.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/test/run.xhtml
@@ -27,7 +27,7 @@
             </h:outputLink>
         </h1>
         <div>
-            <h:outputText value="View expired. Test data is no more available." rendered="#{runBean.expired}" />
+            <h:outputText value="View expired. Test data is no longer available." rendered="#{runBean.expired}" />
 
             <h:panelGroup rendered="#{!runBean.expired}">
                 <h:outputText value="null" rendered="#{empty runBean.results}" />

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/test/test.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/test/test.xhtml
@@ -95,7 +95,7 @@
         </h:panelGroup>
 
         <div style="margin-top: 33px;">
-            <h:outputText value="View expired. Test data is no more available." rendered="#{testBean.expired}" />
+            <h:outputText value="View expired. Test data is no longer available." rendered="#{testBean.expired}" />
 
             <h:panelGroup class="pagination pagination-mini pagination-centered" rendered="#{maxPage > 1}" layout="block">
                 <ul>


### PR DESCRIPTION
A minor update to the wording of some error messages in the Webstudio Webapp HTML