### PR TITLE
EPBDS-11499 generate spreadsheets based on the path and operation method

### DIFF
--- a/STUDIO/org.openl.rules.webstudio.web/test-resources/openapi/functionality/EPBDS-11499_multiple_operations_spreadsheet.json
+++ b/STUDIO/org.openl.rules.webstudio.web/test-resources/openapi/functionality/EPBDS-11499_multiple_operations_spreadsheet.json
@@ -1,0 +1,318 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "myDeploy",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/webservice/REST/myDeploy",
+      "variables": {}
+    }
+  ],
+  "paths": {
+    "/PlanDetails": {
+      "post": {
+        "summary": "bla",
+        "description": "bla",
+        "operationId": "PlanDetails",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Car"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Building"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "bla",
+        "description": "Rules method: int Case13(int a, double b, boolean c)",
+        "operationId": "get123",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "b",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "c",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Car"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/RatingDetails": {
+      "post": {
+        "summary": "Test Rating Details",
+        "description": "second path",
+        "operationId": "RatingDetails",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Car"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Car"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "bla",
+        "description": "Rules method: int Case13(int a, double b, boolean c)",
+        "operationId": "get123",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "b",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "c",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Car"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MyDatatype": {
+        "type": "object",
+        "properties": {
+          "currentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lob": {
+            "type": "string"
+          },
+          "nature": {
+            "type": "string"
+          },
+          "usState": {
+            "type": "string",
+            "enum": [
+              "AL",
+              "AK",
+              "AZ",
+              "AR",
+              "CA",
+              "CO",
+              "WA",
+              "WV",
+              "WI",
+              "WY"
+            ]
+          },
+          "country": {
+            "type": "string",
+            "enum": [
+              "AE",
+              "AL",
+              "AR",
+              "AS",
+              "AT",
+              "VN",
+              "VU",
+              "WS",
+              "YE",
+              "ZA"
+            ]
+          },
+          "usRegion": {
+            "type": "string",
+            "enum": [
+              "MW",
+              "NE",
+              "SE",
+              "SW",
+              "W"
+            ]
+          },
+          "currency": {
+            "type": "string",
+            "enum": [
+              "ALL",
+              "GBP",
+              "USD",
+              "UYU",
+              "VEF",
+              "VND",
+              "YER"
+            ]
+          },
+          "lang": {
+            "type": "string",
+            "enum": [
+              "ALB",
+              "SLO",
+              "SPA",
+              "THA",
+              "TUR",
+              "UKR",
+              "VIE"
+            ]
+          },
+          "region": {
+            "type": "string",
+            "enum": [
+              "NCSA",
+              "EU",
+              "EMEA",
+              "APJ"
+            ]
+          },
+          "caProvince": {
+            "type": "string",
+            "enum": [
+              "AB",
+              "BC",
+              "PE",
+              "MB",
+              "NB",
+              "NS",
+              "NU",
+              "ON",
+              "QC",
+              "SK",
+              "NL",
+              "YT",
+              "NT"
+            ]
+          },
+          "caRegion": {
+            "type": "string",
+            "enum": [
+              "QC",
+              "HQ"
+            ]
+          }
+        }
+      },
+      "PlanDetails": {
+        "type": "object",
+        "properties": {
+          "Plan": {
+            "type": "string"
+          },
+          "Coverages": {
+            "type": "string"
+          }
+        }
+      },
+      "Car": {
+        "type": "object",
+        "properties": {
+          "runtimeContext": {
+            "$ref": "#/components/schemas/MyDatatype"
+          },
+          "plan": {
+            "type": "string"
+          }
+        }
+      },
+      "Building": {
+        "type": "object",
+        "properties": {
+          "PolicyRatesAndPremiums": {
+            "type": "string"
+          },
+          "Plans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlanDetails"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Util/openl-openapi-parser/test/org/openl/rules/OpenAPIConverterTest.java
+++ b/Util/openl-openapi-parser/test/org/openl/rules/OpenAPIConverterTest.java
@@ -283,15 +283,6 @@ public class OpenAPIConverterTest {
     }
 
     @Test
-    public void largeFileTest() throws IOException {
-        ProjectModel projectModel = converter.extractProjectModel("test.converter/twitter.json");
-        List<SpreadsheetModel> spreadsheetModels = projectModel.getSpreadsheetResultModels();
-        Set<DatatypeModel> datatypeModels = projectModel.getDatatypeModels();
-        assertEquals(86, datatypeModels.size());
-        assertEquals(10, spreadsheetModels.size());
-    }
-
-    @Test
     public void testSimpleTypes() throws IOException {
         ProjectModel pm = converter.extractProjectModel("test.converter/problems/simpleTypes.json");
         List<SpreadsheetModel> spreadsheetResultModels = pm.getSpreadsheetResultModels();

--- a/Util/openl-openapi-parser/test/org/openl/rules/SpreadsheetsConverterTest.java
+++ b/Util/openl-openapi-parser/test/org/openl/rules/SpreadsheetsConverterTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -423,7 +424,9 @@ public class SpreadsheetsConverterTest {
         ProjectModel projectModel = converter
             .extractProjectModel("test.converter/spreadsheets/EPBDS-10432_child_spr.json");
         List<SpreadsheetModel> spreadsheetResultModels = projectModel.getSpreadsheetResultModels();
-        Optional<SpreadsheetModel> spr = spreadsheetResultModels.stream().findAny();
+        Optional<SpreadsheetModel> spr = spreadsheetResultModels.stream()
+            .filter(spreadsheet -> spreadsheet.getName().equals("petsAGET"))
+            .findAny();
         assertTrue(spr.isPresent());
         SpreadsheetModel spreadsheetModel = spr.get();
         assertEquals("Pet", spreadsheetModel.getType());


### PR DESCRIPTION
Previously, the full path was marked as the spreadsheet result, now each operation is checked for the conditions.
- fixing the behavior, then all operations were marked as spreadsheet result if only one operation was.
- small refactoring for array checking.
- useless test was removed.