### PR TITLE
EPBDS-10940  Resolve issue with redundant count of local port exposing

### DIFF
--- a/ITEST/itest.ws-rest-rules-deploy/test/org/openl/itest/RunRestRulesDeploymentTest.java
+++ b/ITEST/itest.ws-rest-rules-deploy/test/org/openl/itest/RunRestRulesDeploymentTest.java
@@ -102,11 +102,6 @@ public class RunRestRulesDeploymentTest {
 
         AsyncExecutor executor = new AsyncExecutor(() -> {
             client.send("EPBDS-8758/doSomething.get");
-            try {
-                TimeUnit.MILLISECONDS.sleep(10);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
         });
         TaskScheduler taskScheduler = new TaskScheduler();
 
@@ -141,11 +136,6 @@ public class RunRestRulesDeploymentTest {
 
         AsyncExecutor executor = new AsyncExecutor(() -> {
             client.send("EPBDS-8758/doSomething.get");
-            try {
-                TimeUnit.MILLISECONDS.sleep(10);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
         });
         executor.start();
 

--- a/ITEST/pom.xml
+++ b/ITEST/pom.xml
@@ -90,6 +90,9 @@
                             <server.responses>${project.build.directory}/responses/</server.responses>
                             <http.timeout.connect>${http.timeout.connect}</http.timeout.connect>
                             <http.timeout.read>${http.timeout.read}</http.timeout.read>
+                            <!-- See: https://docs.oracle.com/javase/8/docs/technotes/guides/net/http-keepalive.html -->
+                            <http.maxConnections>50</http.maxConnections>
+                            <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/ITEST/pom.xml
+++ b/ITEST/pom.xml
@@ -90,8 +90,13 @@
                             <server.responses>${project.build.directory}/responses/</server.responses>
                             <http.timeout.connect>${http.timeout.connect}</http.timeout.connect>
                             <http.timeout.read>${http.timeout.read}</http.timeout.read>
-                            <!-- See: https://docs.oracle.com/javase/8/docs/technotes/guides/net/http-keepalive.html -->
-                            <http.maxConnections>50</http.maxConnections>
+                            <!--
+                                Max connections to keep alive. Don't change it without special need.
+                                25 value is chosen because the max thread for parallel tests is 20 + default value 5
+                                See: https://docs.oracle.com/javase/8/docs/technotes/guides/net/http-keepalive.html
+                                -->
+                            <http.maxConnections>25</http.maxConnections>
+                            <!-- Enable Cors header for URL Connection because it's restricted by default -->
                             <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
                         </systemPropertyVariables>
                     </configuration>

--- a/ITEST/server-core/src/org/openl/itest/core/worker/AsyncExecutor.java
+++ b/ITEST/server-core/src/org/openl/itest/core/worker/AsyncExecutor.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
  */
 public class AsyncExecutor {
 
-    private static final int MAX_THREADS = Runtime.getRuntime().availableProcessors() * 2;
+    private static final int MAX_THREADS = Math.min(Runtime.getRuntime().availableProcessors() * 2, 20);
 
     private final ExecutorService executor;
     private final List<Wrapper> workers;


### PR DESCRIPTION
Each new Socket connection exposes new local port, but when a connection is closed, local port is not closed immediately it closed with some delay. Use URL Connection to have the ability to reuse previously created connections. It's support out of the box