### PR TITLE
EPBDS-11809 Add optional Entity ID parameter to the SAML configuration

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/install/InstallWizard.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/install/InstallWizard.java
@@ -242,6 +242,7 @@ public class InstallWizard implements Serializable {
 
     private void readSamlProperties() {
         samlSettings = new SAMLSettings(propertyResolver.getProperty("security.saml.app-url"),
+            propertyResolver.getProperty("security.saml.entity-id"),
             propertyResolver.getProperty("security.saml.saml-server-metadata-url"),
             propertyResolver.getRequiredProperty("security.saml.request-timeout", Integer.class),
             propertyResolver.getProperty("security.saml.keystore-file-path"),
@@ -284,6 +285,9 @@ public class InstallWizard implements Serializable {
                     properties.setProperty("security.cas.attribute.groups", casSettings.getGroupsAttribute());
                 } else if (SAML_USER_MODE.equals(userMode)) {
                     properties.setProperty("security.saml.app-url", samlSettings.getWebStudioUrl());
+                    if (!StringUtils.isBlank(samlSettings.getEntityId())) {
+                        properties.setProperty("security.saml.entity-id", samlSettings.getEntityId());
+                    }
                     properties.setProperty("security.saml.saml-server-metadata-url",
                         samlSettings.getSamlServerMetadataUrl());
                     properties.setProperty("security.saml.request-timeout", samlSettings.getRequestTimeout());

--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/install/SAMLSettings.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/install/SAMLSettings.java
@@ -2,6 +2,7 @@ package org.openl.rules.webstudio.web.install;
 
 public class SAMLSettings {
     private String webStudioUrl;
+    private String entityId;
     private String samlServerMetadataUrl;
     private int requestTimeout;
     private final String keystoreFilePath;
@@ -25,6 +26,7 @@ public class SAMLSettings {
     private String serverCertificate;
 
     public SAMLSettings(String webStudioUrl,
+            String entityId,
             String samlServerMetadataUrl,
             int requestTimeout,
             String keystoreFilePath,
@@ -47,6 +49,7 @@ public class SAMLSettings {
             boolean isAppAfterBalancer,
             String serverCertificate) {
         this.webStudioUrl = webStudioUrl;
+        this.entityId = entityId;
         this.samlServerMetadataUrl = samlServerMetadataUrl;
         this.requestTimeout = requestTimeout;
         this.keystoreFilePath = keystoreFilePath;
@@ -76,6 +79,14 @@ public class SAMLSettings {
 
     public void setWebStudioUrl(String webStudioUrl) {
         this.webStudioUrl = webStudioUrl;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
     }
 
     public String getSamlServerMetadataUrl() {

--- a/STUDIO/org.openl.rules.webstudio/webapp/WEB-INF/spring/security/security-saml.xml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/WEB-INF/spring/security/security-saml.xml
@@ -151,6 +151,7 @@
         <constructor-arg>
             <bean class="org.springframework.security.saml.metadata.MetadataGenerator">
                 <property name="entityBaseURL" value="#{environment.getProperty('security.saml.app-url')}"/>
+                <property name="entityId" value="#{T(org.openl.util.StringUtils).trimToNull(environment.getProperty('security.saml.entity-id'))}" />
             </bean>
         </constructor-arg>
     </bean>

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/install/step3.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/install/step3.xhtml
@@ -267,6 +267,13 @@
                                     </td>
                                 </tr>
                                 <tr>
+                                    <td><label>Entity ID:</label></td>
+                                    <td>
+                                        <h:inputText id="samlEntityId"
+                                                     value="#{installWizard.samlSettings.entityId}" size="40"/>
+                                    </td>
+                                </tr>
+                                <tr>
                                     <td><label>Metadata trust check:</label></td>
                                     <td>
                                         <h:selectBooleanCheckbox id="samlMetadataTrustCheck"


### PR DESCRIPTION
By default org.springframework.security.saml.metadata.MetadataGeneratorFilter uses entity Id derived from the baseUrl.
It makes impossible to configure more than one instance of webstudio using SAML with the same identity provider instance.
Added possibility to use non-default value by setting property security.saml.entity-id property