### PR TITLE
EPBDS-11801 fix cloning of DefaultRulesRuntimeContext instance.

### DIFF
--- a/DEV/org.openl.rules.gen/src/org/openl/codegen/template/DefaultRulesContext-properties.vm
+++ b/DEV/org.openl.rules.gen/src/org/openl/codegen/template/DefaultRulesContext-properties.vm
@@ -1,9 +1,18 @@
+    /**
+    * The default implementation Object.clone() method returns a Shallow Copy.
+    * <p>
+    *     In shallow copy, if the field value is a primitive type, it copies its value; otherwise,
+    *     if the field value is a reference to an object, it copies the reference, hence referring to the same object.
+    *     Now, if one of these objects is modified, the change is visible in the other.
+    * </p>
+    * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#clone()">Object#clone()</a>
+    * @see <a href="https://en.wikipedia.org/wiki/Clone_(Java_method)">Clone (Java_method)</a>
+    */
     @Override
     public IRulesRuntimeContext clone() throws CloneNotSupportedException {
         DefaultRulesRuntimeContext defaultRulesRuntimeContext = (DefaultRulesRuntimeContext) super.clone();
-#foreach( $contextPropertyDefinition in $contextPropertyDefinitions )
-        defaultRulesRuntimeContext.set$tool.formatAccessorName($contextPropertyDefinition.Name)(this.$contextPropertyDefinition.Name);
-#end
+        // create a new instance of `Hashmap`. By default clone creates a shallow copy in defaultRulesRuntimeContext.
+        defaultRulesRuntimeContext.internalMap = new HashMap<>(this.internalMap);
         return defaultRulesRuntimeContext;
     }
 

--- a/DEV/org.openl.rules/src/org/openl/rules/context/DefaultRulesRuntimeContext.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/context/DefaultRulesRuntimeContext.java
@@ -31,7 +31,7 @@ public class DefaultRulesRuntimeContext implements IRulesRuntimeContext, IRulesR
         }
     }
 
-    private final Map<String, Object> internalMap = new HashMap<>();
+    private Map<String, Object> internalMap = new HashMap<>();
 
     @Override
     public Object getValue(String name) {
@@ -130,21 +130,21 @@ public class DefaultRulesRuntimeContext implements IRulesRuntimeContext, IRulesR
     }
 
     // <<< INSERT >>>
+    /**
+    * The default implementation Object.clone() method returns a Shallow Copy.
+    * <p>
+    *     In shallow copy, if the field value is a primitive type, it copies its value; otherwise,
+    *     if the field value is a reference to an object, it copies the reference, hence referring to the same object.
+    *     Now, if one of these objects is modified, the change is visible in the other.
+    * </p>
+    * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#clone()">Object#clone()</a>
+    * @see <a href="https://en.wikipedia.org/wiki/Clone_(Java_method)">Clone (Java_method)</a>
+    */
     @Override
     public IRulesRuntimeContext clone() throws CloneNotSupportedException {
         DefaultRulesRuntimeContext defaultRulesRuntimeContext = (DefaultRulesRuntimeContext) super.clone();
-        defaultRulesRuntimeContext.setCurrentDate(this.currentDate);
-        defaultRulesRuntimeContext.setRequestDate(this.requestDate);
-        defaultRulesRuntimeContext.setLob(this.lob);
-        defaultRulesRuntimeContext.setNature(this.nature);
-        defaultRulesRuntimeContext.setUsState(this.usState);
-        defaultRulesRuntimeContext.setCountry(this.country);
-        defaultRulesRuntimeContext.setUsRegion(this.usRegion);
-        defaultRulesRuntimeContext.setCurrency(this.currency);
-        defaultRulesRuntimeContext.setLang(this.lang);
-        defaultRulesRuntimeContext.setRegion(this.region);
-        defaultRulesRuntimeContext.setCaProvince(this.caProvince);
-        defaultRulesRuntimeContext.setCaRegion(this.caRegion);
+        // create a new instance of `Hashmap`. By default clone creates a shallow copy in defaultRulesRuntimeContext.
+        defaultRulesRuntimeContext.internalMap = new HashMap<>(this.internalMap);
         return defaultRulesRuntimeContext;
     }
 

--- a/DEV/org.openl.rules/test/org/openl/rules/context/DefaultRulesRuntimeContextTest.java
+++ b/DEV/org.openl.rules/test/org/openl/rules/context/DefaultRulesRuntimeContextTest.java
@@ -1,0 +1,45 @@
+package org.openl.rules.context;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+public class DefaultRulesRuntimeContextTest {
+
+    @Test
+    public void testClone() throws CloneNotSupportedException {
+        final Date requestDate = new Date();
+        final Date currentDate = new Date();
+        final String lob = "UL";
+
+        final DefaultRulesRuntimeContext original = new DefaultRulesRuntimeContext();
+        original.setCurrentDate(currentDate);
+        original.setRequestDate(requestDate);
+
+        final DefaultRulesRuntimeContext cloned = (DefaultRulesRuntimeContext) original.clone();
+        assertNotSame(original, cloned);
+        assertSame(currentDate, original.getCurrentDate());
+        assertSame(currentDate, original.getValue("currentDate"));
+        assertSame(currentDate, cloned.getCurrentDate());
+        assertSame(currentDate, cloned.getValue("currentDate"));
+        assertSame(requestDate, original.getRequestDate());
+        assertSame(requestDate, original.getValue("requestDate"));
+        assertSame(requestDate, cloned.getRequestDate());
+        assertSame(requestDate, cloned.getValue("requestDate"));
+        assertEquals(original.toString(), cloned.toString());
+
+        original.setLob(lob);
+        assertSame(lob, original.getLob());
+        assertSame(lob, original.getValue("lob"));
+        assertNotEquals(original.toString(), cloned.toString());
+        assertNull(cloned.getLob());
+        assertNull(cloned.getValue("lob"));
+    }
+
+}


### PR DESCRIPTION
NOTE:
The default implementation Object.clone() method returns a Shallow Copy.
In shallow copy, if the field value is a primitive type, it copies its value; otherwise, if the field value is a reference to an object, it copies the reference, hence referring to the same object. Now, if one of these objects is modified, the change is visible in the other.
Links:
https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#clone()
https://en.wikipedia.org/wiki/Clone_(Java_method)