### PR TITLE
Updating lo4j2 to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <!-- see https://github.com/swagger-api/swagger-core/pull/3637#issuecomment-682370287 -->
         <!-- it needs to wait when it will be fixed or exclude this field from mapping via MixIn -->
         <io.swagger.core.v3.version>2.1.3</io.swagger.core.v3.version>
-        <log4j.version>2.14.1</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
         <org.slf4j.version>1.7.32</org.slf4j.version>
         <org.apache.poi.version>5.1.0</org.apache.poi.version>
         <org.bouncycastle.version>1.70</org.bouncycastle.version>


### PR DESCRIPTION
## What was done
Due to the found vulnerability in log4j2, the version must be updated to 2.15.0. AFAIK, OpenL uses the latest versions of JDKs (at least for in Docker images), so based on this [article](https://www.lunasec.io/docs/blog/log4j-zero-day/#how-the-exploit-works), this vulnerability should not affect the current installations. Anyway, it's better to upgrade the version.  
Feel free to close this pull request and upgrade the log4j2 version in the corresponding tickets for updating the dependencies/fixing vulnerabilities. 🙂 

## Validation
At least locally built was successful on 11 JDK.

### Details about the vulnerability
https://www.lunasec.io/docs/blog/log4j-zero-day/#how-the-exploit-works
https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/