### PR TITLE
EPBDS-11381 do not remove the first slash from group name.

### DIFF
--- a/STUDIO/org.openl.security.cas/src/org/openl/security/cas/CASAttributesToOpenLUserDetailsService.java
+++ b/STUDIO/org.openl.security.cas/src/org/openl/security/cas/CASAttributesToOpenLUserDetailsService.java
@@ -77,19 +77,11 @@ public class CASAttributesToOpenLUserDetailsService extends AbstractCasAssertion
 
                     for (final Object o : list) {
                         String name = o.toString();
-                        if (name.charAt(0) == '/') {
-                            // CAS Groups started with '/' char
-                            name = name.substring(1);
-                        }
                         grantedAuthorities.add(new SimplePrivilege(name, name));
                     }
 
                 } else {
                     String name = value.toString();
-                    if (name.charAt(0) == '/') {
-                        // CAS Groups started with '/' char
-                        name = name.substring(1);
-                    }
                     grantedAuthorities.add(new SimplePrivilege(name, name));
                 }
             }

--- a/STUDIO/org.openl.security.saml/src/org/openl/security/saml/OpenLResponseAuthenticationConverter.java
+++ b/STUDIO/org.openl.security.saml/src/org/openl/security/saml/OpenLResponseAuthenticationConverter.java
@@ -115,10 +115,6 @@ public class OpenLResponseAuthenticationConverter implements Converter<OpenSamlA
             final List<Privilege> grantedAuthorities = new ArrayList<>();
             if (StringUtils.isNotBlank(groupsAttribute)) {
                 for (String name : getAttributeValues(groupsAttribute)) {
-                    if (name.charAt(0) == '/') {
-                        // SAML Groups started with '/' char
-                        name = name.substring(1);
-                    }
                     grantedAuthorities.add(new SimplePrivilege(name, name));
                 }
             }


### PR DESCRIPTION
After investigation it was found that the keycloak has a setting in the mapper, which affects the returned group name
the full path or just the group name can be returned. This is used to be able to organize groups like top/level1/level2.
There is no point in making a custom logic for removing leading slashes, because the keycloak can add a slash in certain cases.
since this slash is not defined in specification of Saml or Cas, so we cannot make logic based on custom IDP implementation.