### PR TITLE
EPBDS-12696 Set up @charset "UTF-8" to force browser to select a required charset

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/webapp/css/common.css
+++ b/STUDIO/org.openl.rules.webstudio/webapp/css/common.css
@@ -1,3 +1,14 @@
+@charset "UTF-8";
+/*
+Needs to set up @charset "UTF-8" to force browser to select a required charset.
+If charset is not defined browser can select an incorrect charset and the specials symbols like "✔" will not be read
+properly.
+For example, the symbol "✔" is U+2713 in unicode, which in UTF-8 is coded as E2 9C 93. But somehow the file
+is read as Windows-1252 where E2 is â, 9C is œ, and 93 is “. And as result it will be displayed as "âœ“" on UI
+
+See: https://www.w3.org/International/questions/qa-css-charset
+*/
+
 body {
     color: #171717;
     background: #fff;

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/adminLayout.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/adminLayout.xhtml
@@ -18,7 +18,7 @@
 
         <link href="#{contextPath}/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
         <link href="#{contextPath}/css/bootstrap.min.css" rel="stylesheet" />
-        <link href="#{contextPath}/css/common.css?8" rel="stylesheet" />
+        <link href="#{contextPath}/css/common.css?9" rel="stylesheet" />
         <link href="#{contextPath}/css/layout/main.css" rel="stylesheet" />
 
         <script src="#{contextPath}/javascript/vendor/jquery-1.7.2.min.js"></script>

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/framePanel.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/framePanel.xhtml
@@ -7,7 +7,7 @@
     <c:set var="contextPath" value="#{facesContext.externalContext.request.contextPath}" />
 
     <h:head>
-        <link href="#{contextPath}/css/common.css?8" rel="stylesheet" />
+        <link href="#{contextPath}/css/common.css?9" rel="stylesheet" />
         <script src="#{contextPath}/javascript/vendor/jquery-1.7.2.min.js"></script>
         <script src="#{contextPath}/javascript/common.js?11"></script>   <!-- increment parameter when js file is changed to force browser to reload cached file -->
 

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/repositoryLayout.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/repositoryLayout.xhtml
@@ -16,7 +16,7 @@
 
         <link href="#{contextPath}/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
         <link href="#{contextPath}/css/bootstrap.min.css" rel="stylesheet" />
-        <link href="#{contextPath}/css/common.css?8" rel="stylesheet" />
+        <link href="#{contextPath}/css/common.css?9" rel="stylesheet" />
         <link href="#{contextPath}/css/layout/main.css" rel="stylesheet" />
         <link href="#{contextPath}/css/jquery.popup.css" rel="stylesheet" />
         <link href="#{contextPath}/css/jquery.multiselect.css" rel="stylesheet" />

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/simpleLayout.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/layout/simpleLayout.xhtml
@@ -12,7 +12,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
         <link href="#{contextPath}/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-        <link href="#{contextPath}/css/common.css?8" rel="stylesheet" />
+        <link href="#{contextPath}/css/common.css?9" rel="stylesheet" />
         <link href="#{contextPath}/css/layout/simple.css" rel="stylesheet" />
         <script src="#{contextPath}/javascript/common.js?11"></script>   <!-- increment parameter when js file is changed to force browser to reload cached file -->
         <script src="#{contextPath}/javascript/vendor/jquery-1.7.2.min.js"></script>

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/index.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/index.xhtml
@@ -17,7 +17,7 @@
 
     <link href="#{contextPath}/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
     <link href="#{contextPath}/css/bootstrap.min.css" rel="stylesheet" />
-    <link href="#{contextPath}/css/common.css?8" rel="stylesheet" />
+    <link href="#{contextPath}/css/common.css?9" rel="stylesheet" />
     <link href="#{contextPath}/css/layout/main.css" rel="stylesheet" />
     <link href="#{contextPath}/css/jquery.popup.css" rel="stylesheet" />
     <link href="#{contextPath}/css/jquery.multiselect.css" rel="stylesheet" />


### PR DESCRIPTION
If charset is not defined browser can select an incorrect charset and the specials symbols like "✔" will not be read
properly.
For example, the symbol "✔" is U+2713 in unicode, which in UTF-8 is coded as E2 9C 93. But somehow the file
is read as Windows-1252 where E2 is â, 9C is œ, and 93 is “. And as result it will be displayed as "âœ“" on UI

See: https://www.w3.org/International/questions/qa-css-charset