### PR TITLE
EPBDS-12840 extend groupName field length. 64 chars is optimal group name length

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/webstudio/service/GroupManagementTest.java
+++ b/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/webstudio/service/GroupManagementTest.java
@@ -314,6 +314,22 @@ public class GroupManagementTest {
         assertEquals(1, queryCount.getTotal());
     }
 
+    @Test
+    public void testSaveLongGroupName() {
+        initOneUser();
+        externalGroupService.mergeAllForUser("jdoe", Collections.singleton(new SimplePrivilege("foo-bar".repeat(9))));
+        QueryCount queryCount = QueryCountHolder.getGrandTotal();
+        assertEquals(1, queryCount.getInsert());
+        assertEquals(1, queryCount.getDelete());
+        assertEquals(2, queryCount.getTotal());
+
+        QueryCountHolder.clear();
+        groupService.addGroup("foo-bar".repeat(9), "Long Group Name");
+        queryCount = QueryCountHolder.getGrandTotal();
+        assertEquals(1, queryCount.getInsert());
+        assertEquals(1, queryCount.getTotal());
+    }
+
     private static <T, R> void assertCollectionEquals(Collection<R> expected,
             Collection<T> actual,
             Function<T, R> attr) {
@@ -335,7 +351,7 @@ public class GroupManagementTest {
 
     private Set<Privilege> generatePrivilege(int count, String... defaultGroups) {
         Set<Privilege> res = new HashSet<>();
-        Stream.of(defaultGroups).map(name -> new SimplePrivilege(name)).forEach(res::add);
+        Stream.of(defaultGroups).map(SimplePrivilege::new).forEach(res::add);
         for (int i = 0; i < count; i++) {
             String name = String.format(RND_GROUP, i);
             res.add(new SimplePrivilege(name));

--- a/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/administration/users/groups.xhtml
+++ b/STUDIO/org.openl.rules.webstudio/webapp/pages/modules/administration/users/groups.xhtml
@@ -163,7 +163,7 @@
                     </td>
                     <td>
                         <input type="hidden" name="oldName"/>
-                        <input type="text" name="name" style="margin-right: 7px;" maxlength="40"/>
+                        <input type="text" name="name" style="margin-right: 7px;" maxlength="65"/>
                         <span class="error"/>
                     </td>
                 </tr>

--- a/STUDIO/org.openl.security.standalone/resources/db/flyway/h2/V8__Extend_Group_Name_Length.sql
+++ b/STUDIO/org.openl.security.standalone/resources/db/flyway/h2/V8__Extend_Group_Name_Length.sql
@@ -1,0 +1,3 @@
+ALTER TABLE OpenL_External_Groups ALTER COLUMN groupName SET DATA TYPE ${varchar}(65);
+
+ALTER TABLE OpenL_Groups ALTER COLUMN groupName SET DATA TYPE ${varchar}(65);

--- a/STUDIO/org.openl.security.standalone/resources/db/flyway/microsoft_sql_server/V8__Extend_Group_Name_Length.sql
+++ b/STUDIO/org.openl.security.standalone/resources/db/flyway/microsoft_sql_server/V8__Extend_Group_Name_Length.sql
@@ -1,0 +1,20 @@
+/* Drop previously created PK for OpenL_External_Groups. Because it was created without specific name */
+DECLARE @SQL VARCHAR(4000)
+SET @SQL = 'ALTER TABLE OpenL_External_Groups DROP CONSTRAINT |ConstraintName| '
+SET @SQL = REPLACE(@SQL, '|ConstraintName|', (SELECT name
+                                              FROM sysobjects
+                                              WHERE xtype = 'PK'
+                                                AND parent_obj = OBJECT_ID('OpenL_External_Groups')))
+EXEC (@SQL);
+
+/* Alter groupName column of OpenL_External_Groups table */
+ALTER TABLE OpenL_External_Groups
+    ALTER COLUMN groupName ${varchar}(65) NOT NULL;
+
+/* Create new composite PK for OpenL_External_Groups table */
+ALTER TABLE OpenL_External_Groups
+    ADD CONSTRAINT PK_OpenL_External_Group PRIMARY KEY (loginName, groupName);
+
+/* Alter groupName column of OpenL_External_Groups table */
+ALTER TABLE OpenL_Groups
+    ALTER COLUMN groupName ${varchar}(65) not null;

--- a/STUDIO/org.openl.security.standalone/resources/db/flyway/mysql/V8__Extend_Group_Name_Length.sql
+++ b/STUDIO/org.openl.security.standalone/resources/db/flyway/mysql/V8__Extend_Group_Name_Length.sql
@@ -1,0 +1,3 @@
+ALTER TABLE OpenL_External_Groups MODIFY groupName ${varchar}(65) NOT NULL;
+
+ALTER TABLE OpenL_Groups MODIFY groupName ${varchar}(65) NOT NULL;

--- a/STUDIO/org.openl.security.standalone/resources/db/flyway/oracle/V8__Extend_Group_Name_Length.sql
+++ b/STUDIO/org.openl.security.standalone/resources/db/flyway/oracle/V8__Extend_Group_Name_Length.sql
@@ -1,0 +1,3 @@
+ALTER TABLE OpenL_External_Groups MODIFY groupName ${varchar}(65);
+
+ALTER TABLE OpenL_Groups MODIFY groupName ${varchar}(65);

--- a/STUDIO/org.openl.security.standalone/resources/db/flyway/postgresql/V8__Extend_Group_Name_Length.sql
+++ b/STUDIO/org.openl.security.standalone/resources/db/flyway/postgresql/V8__Extend_Group_Name_Length.sql
@@ -1,0 +1,3 @@
+ALTER TABLE OpenL_External_Groups ALTER COLUMN groupName TYPE ${varchar}(65);
+
+ALTER TABLE OpenL_Groups ALTER COLUMN groupName TYPE ${varchar}(65);

--- a/STUDIO/org.openl.security.standalone/src/org/openl/rules/security/standalone/persistence/ExternalGroup.java
+++ b/STUDIO/org.openl.security.standalone/src/org/openl/rules/security/standalone/persistence/ExternalGroup.java
@@ -16,7 +16,7 @@ public class ExternalGroup implements Serializable {
     private static final long serialVersionUID = 5117085519399896506L;
 
     @Id
-    @Column(name = "groupName", length = 50)
+    @Column(name = "groupName", length = 65)
     private String groupName;
 
     @Id

--- a/STUDIO/org.openl.security.standalone/src/org/openl/rules/security/standalone/persistence/Group.java
+++ b/STUDIO/org.openl.security.standalone/src/org/openl/rules/security/standalone/persistence/Group.java
@@ -62,7 +62,7 @@ public class Group implements Serializable {
      *
      * @return
      */
-    @Column(length = 40, name = "groupName", unique = true, nullable = false)
+    @Column(length = 65, name = "groupName", unique = true, nullable = false)
     public String getName() {
         return name;
     }


### PR DESCRIPTION
See https://www.ibm.com/docs/en/sva/10.0.3?topic=differences-length-names