### PR TITLE
EPBDS-13729 Fix mapping to MIME type for some file extensions

### DIFF
--- a/WSFrontend/org.openl.rules.ruleservice.ws/src/org/openl/rules/ruleservice/servlet/RuleServicesFilter.java
+++ b/WSFrontend/org.openl.rules.ruleservice.ws/src/org/openl/rules/ruleservice/servlet/RuleServicesFilter.java
@@ -1,7 +1,7 @@
 package org.openl.rules.ruleservice.servlet;
 
 import java.io.IOException;
-import java.net.URLConnection;
+import java.net.FileNameMap;
 import java.util.Arrays;
 import java.util.UUID;
 import javax.servlet.Filter;
@@ -41,6 +41,9 @@ public class RuleServicesFilter implements Filter {
 
     private final Logger log = LoggerFactory.getLogger(RuleServicesFilter.class);
 
+    // Mapping from the file extension to the MIME type.
+    private FileNameMap mimeMap;
+
     // MDC
     private static final String REQUEST_ID_KEY = "requestId";
     private String requestIdHeaderKey;
@@ -57,7 +60,10 @@ public class RuleServicesFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        ApplicationContext appContext = SpringInitializer.getApplicationContext(filterConfig.getServletContext());
+        var servletContext = filterConfig.getServletContext();
+        mimeMap = servletContext::getMimeType;
+
+        ApplicationContext appContext = SpringInitializer.getApplicationContext(servletContext);
         Environment env = appContext.getEnvironment();
 
         // MDC
@@ -115,7 +121,7 @@ public class RuleServicesFilter implements Filter {
             try (var resourceStream = getClass().getClassLoader().getResourceAsStream("static" + path)) {
                 if (resourceStream != null) {
                     response.setStatus(HttpServletResponse.SC_OK);
-                    var mimeType = URLConnection.getFileNameMap().getContentTypeFor(path);
+                    var mimeType = mimeMap.getContentTypeFor(path);
 
                     response.setContentType(mimeType);
                     resourceStream.transferTo(resp.getOutputStream());
@@ -200,5 +206,6 @@ public class RuleServicesFilter implements Filter {
     public void destroy() {
         OpenLInfoLogger.memStat();
         authorizationCheckers = null;
+        mimeMap = null;
     }
 }


### PR DESCRIPTION
Java provides limited amount of MIME types by default the set of which depends on the OS.

Servlet API provides more flexibility by defining them in the servlet context.