### PR TITLE
EPBDS-14625: db maximum pool size configurable

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/resources/openl-default.properties
+++ b/STUDIO/org.openl.rules.webstudio/resources/openl-default.properties
@@ -66,7 +66,7 @@ openl.compatibility.version =
 db.url = jdbc:h2:${openl.home}/users-db/db;AUTO_SERVER=TRUE
 db.user =
 db.password =
-
+# Limit of the connections to the DB defined in the connection pool
 db.maximumPoolSize = 50
 ###
 

--- a/STUDIO/org.openl.rules.webstudio/resources/openl-default.properties
+++ b/STUDIO/org.openl.rules.webstudio/resources/openl-default.properties
@@ -66,6 +66,8 @@ openl.compatibility.version =
 db.url = jdbc:h2:${openl.home}/users-db/db;AUTO_SERVER=TRUE
 db.user =
 db.password =
+
+db.maximumPoolSize = 50
 ###
 
 ### Mail server connection

--- a/STUDIO/org.openl.security.standalone/resources/META-INF/standalone/spring/security-hibernate-beans.xml
+++ b/STUDIO/org.openl.security.standalone/resources/META-INF/standalone/spring/security-hibernate-beans.xml
@@ -16,7 +16,7 @@
         <property name="username" value="${db.user}"/>
         <property name="password" value="${db.password}"/>
         <property name="leakDetectionThreshold" value="60000"/>
-        <property name="maximumPoolSize" value="50"/>
+        <property name="maximumPoolSize" value="${db.maximumPoolSize}"/>
     </bean>
 
     <bean id="openlSessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean"


### PR DESCRIPTION
Maximum pool size for database configurable

Motivation : when using OpenlTablets is environments, where number of connections to database is limited (like in public cloud), we should have the capability to limit it. 