### PR TITLE
EPBDS-16182 Issue SAML LogoutRequest on logout so the IdP ends its session

### DIFF
--- a/Docs/api/personal-access-token-architecture.md
+++ b/Docs/api/personal-access-token-architecture.md
@@ -1476,7 +1476,7 @@ Content-Type: application/json
 **Test Execution**:
 ```bash
 cd ITEST/itest.webstudio
-mvn clean verify -Dtest=KeycloakTest
+mvn clean verify -Dtest=OAuthTest
 ```
 
 ---

--- a/ITEST/itest.webstudio/openl-repository/application-saml.properties
+++ b/ITEST/itest.webstudio/openl-repository/application-saml.properties
@@ -1,0 +1,20 @@
+repository.design.$ref = repo-jdbc
+repository.design.name = H2
+repository.design.uri = jdbc:h2:mem:design-repo;DB_CLOSE_DELAY=-1
+
+design-git.$ref = repo-git
+design-git.comment-template.$ref = repo-default.design.comment-template
+
+repository.design-flat.$ref = design-git
+repository.design-flat.name = Git Flat
+repository.design-flat.uri = ${openl.home}/repositories/design-flat
+repository.design-flat.comment-template.invalid-comment-message = 'Invalid comment'
+
+design-repository-configs = design, design-flat
+
+production-repository-configs = production-s3
+repository.production-s3.$ref = repo-aws-s3
+repository.production-s3.name = Deployment S3
+repository.production-s3.base.path.$ref = repo-default.production.base.path
+repository.production-s3.bucket-name = openl-test-deploy
+repository.production-s3.region-name = us-east-1

--- a/ITEST/itest.webstudio/test-resources-saml/set-authentication-template.json
+++ b/ITEST/itest.webstudio/test-resources-saml/set-authentication-template.json
@@ -1,0 +1,18 @@
+{
+  "userMode": "saml",
+  "administrators": ["admin"],
+  "defaultGroup": "Viewers",
+  "allowProjectCreateDelete": true,
+  "entityId": "openlstudio-saml",
+  "metadataUrl": null,
+  "serverCertificate": "",
+  "forceAuthN": false,
+  "attributes": {
+    "username": "",
+    "firstName": "urn:oid:2.5.4.42",
+    "lastName": "urn:oid:2.5.4.4",
+    "displayName": "urn:oid:2.16.840.1.113730.3.1.241",
+    "email": "urn:oid:0.9.2342.19200300.100.1.3",
+    "groups": "groups"
+  }
+}

--- a/ITEST/itest.webstudio/test-resources/openlstudio-realm.json
+++ b/ITEST/itest.webstudio/test-resources/openlstudio-realm.json
@@ -955,6 +955,44 @@
   },
   "clients": [
     {
+      "clientId": "openlstudio-saml",
+      "name": "OpenL Studio SAML",
+      "enabled": true,
+      "protocol": "saml",
+      "fullScopeAllowed": true,
+      "standardFlowEnabled": true,
+      "frontchannelLogout": true,
+      "consentRequired": false,
+      "redirectUris": [
+        "*"
+      ],
+      "attributes": {
+        "saml.assertion.signature": "true",
+        "saml.server.signature": "true",
+        "saml.client.signature": "false",
+        "saml.encrypt": "false",
+        "saml.authnstatement": "true",
+        "saml.force.post.binding": "true",
+        "saml.signature.algorithm": "RSA_SHA256",
+        "saml_name_id_format": "username",
+        "saml_force_name_id_format": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "saml",
+          "protocolMapper": "saml-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "Basic",
+            "single": "true",
+            "full.path": "false",
+            "attribute.name": "groups"
+          }
+        }
+      ]
+    },
+    {
       "id": "81dc05a7-016e-4607-8495-8c0c820de067",
       "clientId": "account",
       "name": "${client_account}",

--- a/ITEST/itest.webstudio/test/org/openl/itest/AbstractKeycloakTest.java
+++ b/ITEST/itest.webstudio/test/org/openl/itest/AbstractKeycloakTest.java
@@ -1,0 +1,68 @@
+package org.openl.itest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import org.apache.http.HttpStatus;
+
+import org.openl.itest.core.JettyServer;
+
+/**
+ * Shared setup for integration tests that drive OpenL Studio against a Keycloak Identity Provider: the
+ * realm-backed Keycloak container, the Studio server wired to an S3 design repository, and the
+ * login-lifecycle assertions reused by the OAuth2 and SAML tests.
+ *
+ * @author Yury Molchan
+ */
+abstract class AbstractKeycloakTest {
+
+    protected final ObjectMapper mapper = new ObjectMapper();
+
+    @SuppressWarnings("resource")
+    protected static KeycloakContainer keycloak() {
+        return new KeycloakContainer("quay.io/keycloak/keycloak:latest")
+                .withRealmImportFile("/openlstudio-realm.json");
+    }
+
+    protected static JettyServer studio(String profile, S3MockContainer s3) {
+        return JettyServer.get()
+                .withProfile(profile)
+                .withInitParam("repository.production-s3.service-endpoint", s3.getHttpEndpoint())
+                .withInitParam("repository.production-s3.access-key", "access key")
+                .withInitParam("repository.production-s3.secret-key", "secret key");
+    }
+
+    /**
+     * Asserts an unauthenticated client is challenged: the home page redirects to {@code loginEntry} and the
+     * REST API answers 401.
+     */
+    protected void assertProtected(SsoBrowser browser, String loginEntry) throws Exception {
+        var landing = browser.get("/");
+        assertEquals(HttpStatus.SC_MOVED_TEMPORARILY, landing.statusCode());
+        assertTrue("Expected a redirect to the login entry " + loginEntry + " but was: "
+                        + landing.headers().firstValue("Location"),
+                landing.headers().firstValue("Location").orElseThrow().endsWith(loginEntry));
+        assertRestUnauthorized(browser);
+    }
+
+    /**
+     * Asserts the session resolves to the {@code admin} user with the administrator authority.
+     */
+    protected void assertAdminSession(SsoBrowser browser) throws Exception {
+        var profile = browser.get("/rest/users/profile");
+        assertEquals(HttpStatus.SC_OK, profile.statusCode());
+        var user = mapper.readTree(profile.body());
+        assertEquals("admin", user.get("username").asText());
+        assertTrue("admin must be mapped to an administrator", user.get("administrator").asBoolean());
+    }
+
+    /**
+     * Asserts that the REST API rejects the current client as unauthenticated.
+     */
+    protected void assertRestUnauthorized(SsoBrowser browser) throws Exception {
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, browser.get("/rest/users/profile").statusCode());
+    }
+}

--- a/ITEST/itest.webstudio/test/org/openl/itest/OAuthTest.java
+++ b/ITEST/itest.webstudio/test/org/openl/itest/OAuthTest.java
@@ -9,6 +9,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -21,45 +22,31 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import dasniko.testcontainers.keycloak.KeycloakContainer;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-import org.openl.itest.core.JettyServer;
-
 @DisabledIfSystemProperty(named = "noDocker", matches = ".*")
-public class KeycloakTest {
+public class OAuthTest extends AbstractKeycloakTest {
 
     private static final String CLIENT_ID = "openlstudio";
     private static final String CLIENT_SECRET = "kXo86nuTdOYQzPZ7k09G7vQmqeDNNZoM";
 
-    private final HttpClient client = HttpClient.newHttpClient();
-    private final ObjectMapper mapper = new ObjectMapper();
-
-    @SuppressWarnings("resource")
-    private static KeycloakContainer createKeycloakContainer() {
-        return new KeycloakContainer("quay.io/keycloak/keycloak:latest")
-                .withRealmImportFile("/openlstudio-realm.json");
-    }
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofMillis(Integer.parseInt(System.getProperty("http.timeout.connect"))))
+            .build();
 
     @Test
     public void smoke() throws Exception {
-        try (var keycloack = createKeycloakContainer();
+        try (var keycloack = keycloak();
              var s3 = new S3MockContainer("latest")) {
             keycloack.start();
             s3.start();
             var authServerUrl = keycloack.getAuthServerUrl();
             var bearerTokens = retrieveBearerAccessTokens(authServerUrl);
-            try (var httpClient = JettyServer.get()
-                        .withProfile("oauth2")
-                        .withInitParam("repository.production-s3.service-endpoint", s3.getHttpEndpoint())
-                        .withInitParam("repository.production-s3.access-key", "access key")
-                        .withInitParam("repository.production-s3.secret-key", "secret key")
-                        .start()) {
+            try (var httpClient = studio("oauth2", s3).start()) {
                 initStudio(httpClient, authServerUrl);
 
                 httpClient.localEnv.putAll(bearerTokens);
@@ -74,18 +61,13 @@ public class KeycloakTest {
 
     @Test
     public void smokePat() throws Exception {
-        try (var keycloack = createKeycloakContainer();
+        try (var keycloack = keycloak();
              var s3 = new S3MockContainer("latest")) {
             keycloack.start();
             s3.start();
             var authServerUrl = keycloack.getAuthServerUrl();
             var bearerTokens = retrieveBearerAccessTokens(authServerUrl);
-            try (var httpClient = JettyServer.get()
-                    .withProfile("oauth2")
-                    .withInitParam("repository.production-s3.service-endpoint", s3.getHttpEndpoint())
-                    .withInitParam("repository.production-s3.access-key", "access key")
-                    .withInitParam("repository.production-s3.secret-key", "secret key")
-                    .start()) {
+            try (var httpClient = studio("oauth2", s3).start()) {
                 initStudio(httpClient, authServerUrl);
 
                 httpClient.localEnv.putAll(bearerTokens);
@@ -126,6 +108,40 @@ public class KeycloakTest {
         }
     }
 
+    @Test
+    public void singleLogout() throws Exception {
+        try (var keycloack = keycloak();
+             var s3 = new S3MockContainer("latest")) {
+            keycloack.start();
+            s3.start();
+            var authServerUrl = keycloack.getAuthServerUrl();
+            try (var httpClient = studio("oauth2", s3).start()) {
+                initStudio(httpClient, authServerUrl);
+
+                var browser = new SsoBrowser(httpClient.getBaseURL());
+
+                // Unauthenticated access is challenged.
+                assertProtected(browser, "/oauth2/authorization/webstudio");
+
+                // Log in; the session resolves to admin.
+                browser.loginViaOAuth2("admin", "admin");
+                assertAdminSession(browser);
+
+                // SP-initiated logout redirects to the OIDC end-session endpoint with the id_token_hint.
+                var logoutRedirect = browser.logoutViaOAuth2();
+                assertTrue("Unexpected logout redirect: " + logoutRedirect,
+                        logoutRedirect.startsWith(authServerUrl + "/realms/openlstudio/protocol/openid-connect/logout"));
+                assertTrue("Logout must pass the id_token_hint: " + logoutRedirect,
+                        logoutRedirect.contains("id_token_hint="));
+
+                // Local session cleared; the IdP requires re-authentication.
+                assertRestUnauthorized(browser);
+                assertTrue("Keycloak must require re-authentication after logout",
+                        browser.oauth2ChallengesForLogin());
+            }
+        }
+    }
+
     private Map<String, String> retrieveBearerAccessTokens(String authServerUrl) throws URISyntaxException, IOException, InterruptedException {
         Map<String, String> tokens = new HashMap<>();
         tokens.put("ADMIN_ACCESS_TOKEN", getAccessTokenForUser(authServerUrl, "admin", "admin"));
@@ -162,6 +178,7 @@ public class KeycloakTest {
         var request = HttpRequest.newBuilder()
                 .uri(new URI(authServerUrl + "/realms/openlstudio/protocol/openid-connect/token"))
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED)
+                .timeout(Duration.ofMillis(Integer.parseInt(System.getProperty("http.timeout.read"))))
                 .POST(HttpRequest.BodyPublishers.ofString("grant_type=password&scope=openid profile email" +
                         "&client_id=" + CLIENT_ID +
                         "&client_secret=" + CLIENT_SECRET +

--- a/ITEST/itest.webstudio/test/org/openl/itest/SamlTest.java
+++ b/ITEST/itest.webstudio/test/org/openl/itest/SamlTest.java
@@ -1,0 +1,59 @@
+package org.openl.itest;
+
+import static org.junit.Assert.assertTrue;
+
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * Verifies the SAML 2.0 login and SP-initiated Single Logout lifecycle against a real Keycloak Identity
+ * Provider. Mirrors the OAuth2 scenario in {@link OAuthTest#singleLogout()}.
+ *
+ * @author Yury Molchan
+ */
+@DisabledIfSystemProperty(named = "noDocker", matches = ".*")
+public class SamlTest extends AbstractKeycloakTest {
+
+    private static final String ENTITY_ID = "openlstudio-saml";
+
+    @Test
+    public void singleLogout() throws Exception {
+        try (var keycloak = keycloak();
+             var s3 = new S3MockContainer("latest")) {
+            keycloak.start();
+            s3.start();
+            var authServerUrl = keycloak.getAuthServerUrl();
+            try (var httpClient = studio("saml", s3).start()) {
+                initStudio(httpClient, authServerUrl);
+
+                var browser = new SsoBrowser(httpClient.getBaseURL());
+
+                // Unauthenticated access is challenged.
+                assertProtected(browser, "/saml2/authenticate/webstudio");
+
+                // Log in; the session resolves to admin.
+                browser.loginViaSaml("admin", "admin");
+                assertAdminSession(browser);
+
+                // SP-initiated logout sends a SAML LogoutRequest to the IdP Single Logout Service.
+                var logoutDestination = browser.logoutViaSaml();
+                assertTrue("Logout must target the IdP Single Logout Service: " + logoutDestination,
+                        logoutDestination.startsWith(authServerUrl + "/realms/openlstudio/protocol/saml"));
+
+                // Local session cleared; the IdP requires re-authentication.
+                assertRestUnauthorized(browser);
+                assertTrue("Keycloak must require re-authentication after logout",
+                        browser.samlChallengesForLogin());
+            }
+        }
+    }
+
+    private void initStudio(org.openl.itest.core.HttpClient httpClient, String authServerUrl) {
+        var samlConfig = (ObjectNode) httpClient.readTree("test-resources-saml/set-authentication-template.json");
+        samlConfig.put("metadataUrl", authServerUrl + "/realms/openlstudio/protocol/saml/descriptor");
+        samlConfig.put("entityId", ENTITY_ID);
+        httpClient.postForObject("/rest/admin/settings/authentication", samlConfig);
+    }
+}

--- a/ITEST/itest.webstudio/test/org/openl/itest/SsoBrowser.java
+++ b/ITEST/itest.webstudio/test/org/openl/itest/SsoBrowser.java
@@ -1,0 +1,218 @@
+package org.openl.itest;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Browser emulation for a Keycloak SSO login and SP-initiated logout across the two hosts (OpenL Studio
+ * and the IdP). Follows redirects manually so each hop can be inspected, keeps a cookie jar, and submits
+ * the Keycloak login and HTTP-POST binding forms.
+ *
+ * <p>The cookie jar clears the {@code Secure} flag: Keycloak sets {@code Secure;SameSite=None} cookies and
+ * the test uses plain HTTP.
+ *
+ * @author Yury Molchan
+ */
+class SsoBrowser {
+
+    private static final Pattern LOGIN_FORM_ACTION = Pattern.compile("(?s)id=\"kc-form-login\".*?action=\"([^\"]+)\"");
+    private static final Pattern FORM_ACTION = Pattern.compile("(?s)<form[^>]*action=\"([^\"]+)\"");
+    private static final Pattern HIDDEN_INPUT = Pattern.compile("(?s)name=\"([^\"]+)\"[^>]*?value=\"([^\"]*)\"");
+
+    private final URI base;
+    private final HttpClient http;
+    private final Duration requestTimeout;
+
+    SsoBrowser(URI base) {
+        this.base = base;
+        var builder = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .cookieHandler(insecureCookieManager());
+        int connectTimeout = Integer.parseInt(System.getProperty("http.timeout.connect"));
+        if (connectTimeout > 0) {
+            builder.connectTimeout(Duration.ofMillis(connectTimeout));
+        }
+        this.http = builder.build();
+        this.requestTimeout = Duration.ofMillis(Integer.parseInt(System.getProperty("http.timeout.read")));
+    }
+
+    /**
+     * Logs in through the OpenID Connect authorization-code flow, ending on an authenticated session.
+     */
+    void loginViaOAuth2(String username, String password) throws Exception {
+        var loginPage = followRedirects(get(base.resolve("/")));
+        var afterCredentials = submitCredentials(loginPage.body(), username, password);
+        followRedirects(afterCredentials);
+    }
+
+    /**
+     * Logs in through SAML 2.0: posts the AuthnRequest auto-submit form to Keycloak, submits the
+     * credentials, then posts the SAML response back to the assertion consumer service.
+     */
+    void loginViaSaml(String username, String password) throws Exception {
+        var authnRequestForm = followRedirects(get(base.resolve("/")));
+        var loginPage = followRedirects(submitAutoPostForm(authnRequestForm.body()));
+        var samlResponse = submitCredentials(loginPage.body(), username, password);
+        if (isRedirect(samlResponse)) {
+            followRedirects(samlResponse);
+        } else {
+            followRedirects(submitAutoPostForm(samlResponse.body()));
+        }
+    }
+
+    /**
+     * Sends a GET to a path relative to the OpenL Studio base URL without following redirects.
+     */
+    HttpResponse<String> get(String path) throws Exception {
+        return get(base.resolve(path));
+    }
+
+    /**
+     * Runs SP-initiated OpenID Connect logout, delivers it to Keycloak to end the IdP session, and returns
+     * the IdP end-session endpoint.
+     */
+    String logoutViaOAuth2() throws Exception {
+        var response = get(base.resolve("/logout"));
+        if (!isRedirect(response)) {
+            throw new AssertionError("Expected a redirect from /logout but got " + response.statusCode());
+        }
+        var endpoint = response.headers().firstValue("Location").orElseThrow();
+        get(URI.create(endpoint)); // deliver the request so Keycloak ends the SSO session
+        return endpoint;
+    }
+
+    /**
+     * Runs SP-initiated SAML logout, delivers the LogoutRequest to Keycloak to end the IdP session, and
+     * returns the IdP Single Logout Service endpoint. Handles the HTTP-Redirect and HTTP-POST bindings.
+     */
+    String logoutViaSaml() throws Exception {
+        var response = get(base.resolve("/logout"));
+        if (isRedirect(response)) {
+            var location = response.headers().firstValue("Location").orElseThrow();
+            if (!location.contains("SAMLRequest")) {
+                throw new AssertionError("Logout redirect carries no SAMLRequest: " + location);
+            }
+            get(URI.create(location)); // deliver the request so Keycloak ends the SSO session
+            return location;
+        }
+        if (!response.body().contains("SAMLRequest")) {
+            throw new AssertionError("Logout issued no SAML LogoutRequest (status " + response.statusCode() + "):\n"
+                    + response.body());
+        }
+        submitAutoPostForm(response.body()); // deliver the request so Keycloak ends the SSO session
+        return htmlUnescape(group(response.body(), FORM_ACTION));
+    }
+
+    /**
+     * Returns whether a fresh OpenID Connect login is challenged for credentials, i.e. the IdP session ended.
+     */
+    boolean oauth2ChallengesForLogin() throws Exception {
+        return followRedirects(get(base.resolve("/"))).body().contains("kc-form-login");
+    }
+
+    /**
+     * Returns whether a fresh SAML login is challenged for credentials, i.e. the IdP session ended.
+     */
+    boolean samlChallengesForLogin() throws Exception {
+        var authnRequestForm = followRedirects(get(base.resolve("/")));
+        return followRedirects(submitAutoPostForm(authnRequestForm.body())).body().contains("kc-form-login");
+    }
+
+    private HttpResponse<String> submitCredentials(String loginPage, String username, String password) throws Exception {
+        var action = URI.create(htmlUnescape(group(loginPage, LOGIN_FORM_ACTION)));
+        var form = "username=" + encode(username) + "&password=" + encode(password) + "&credentialId=";
+        return postForm(action, form);
+    }
+
+    /**
+     * Posts every hidden input of an HTTP-POST binding auto-submit form to its action. SAML values are MIME
+     * base64, so line breaks and CR entities are stripped first.
+     */
+    private HttpResponse<String> submitAutoPostForm(String html) throws Exception {
+        var action = URI.create(htmlUnescape(group(html, FORM_ACTION)));
+        var form = new StringBuilder();
+        var matcher = HIDDEN_INPUT.matcher(html);
+        while (matcher.find()) {
+            var value = htmlUnescape(matcher.group(2).replaceAll("&#1[03];|\\s+", ""));
+            if (!form.isEmpty()) {
+                form.append('&');
+            }
+            form.append(encode(matcher.group(1))).append('=').append(encode(value));
+        }
+        return postForm(action, form.toString());
+    }
+
+    private HttpResponse<String> followRedirects(HttpResponse<String> response) throws Exception {
+        var current = response;
+        for (int hop = 0; hop < 10 && isRedirect(current); hop++) {
+            var location = current.headers().firstValue("Location").orElseThrow();
+            current = get(current.uri().resolve(location));
+        }
+        return current;
+    }
+
+    private HttpResponse<String> get(URI uri) throws Exception {
+        return http.send(request(uri).GET().build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> postForm(URI uri, String body) throws Exception {
+        var req = request(uri)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpRequest.Builder request(URI uri) {
+        return HttpRequest.newBuilder(uri).timeout(requestTimeout);
+    }
+
+    // Keycloak sets Secure;SameSite=None cookies; clear Secure so they are sent over the test's plain HTTP.
+    private static CookieManager insecureCookieManager() {
+        return new CookieManager(null, CookiePolicy.ACCEPT_ALL) {
+            @Override
+            public void put(URI uri, Map<String, List<String>> responseHeaders) throws IOException {
+                super.put(uri, responseHeaders);
+                for (HttpCookie cookie : getCookieStore().getCookies()) {
+                    cookie.setSecure(false);
+                }
+            }
+        };
+    }
+
+    private static boolean isRedirect(HttpResponse<?> response) {
+        return response.statusCode() >= 300 && response.statusCode() < 400;
+    }
+
+    private static String group(String html, Pattern pattern) {
+        Matcher matcher = pattern.matcher(html);
+        if (!matcher.find()) {
+            throw new AssertionError("Pattern " + pattern + " not found in response:\n" + html);
+        }
+        return matcher.group(1);
+    }
+
+    private static String htmlUnescape(String value) {
+        return value.replace("&amp;", "&")
+                .replace("&#x2F;", "/")
+                .replace("&#47;", "/")
+                .replace("&quot;", "\"");
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/ITEST/server-core/src/org/openl/itest/core/HttpClient.java
+++ b/ITEST/server-core/src/org/openl/itest/core/HttpClient.java
@@ -301,6 +301,13 @@ public class HttpClient implements AutoCloseable {
     }
 
     /**
+     * @return the {@code http://...} base URL the server is bound to.
+     */
+    public URI getBaseURL() {
+        return baseURL;
+    }
+
+    /**
      * @return the {@code ws://...} URL that the server's STOMP endpoint is served from.
      */
     public URI getWebSocketBaseURL() {

--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/studio/security/SamlSecurityConfig.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/studio/security/SamlSecurityConfig.java
@@ -54,12 +54,15 @@ public class SamlSecurityConfig {
     @Order(1)
     public SecurityFilterChain logoutFilterChain(
             @Qualifier("securityContextPersistenceFilter") SecurityContextPersistenceFilter securityContextPersistenceFilter,
-            Saml2LogoutRequestFilter logoutFilter) {
+            Saml2LogoutRequestFilter logoutFilter,
+            SamlLogoutSuccessHandler samlLogoutHandler) {
 
+        // samlLogoutHandler clears the local session and sends a SAML LogoutRequest to the IdP Single
+        // Logout Service, ending the IdP session. A no-op handler here would log out locally only.
         return new DefaultSecurityFilterChain(RequestMatchers.matcher("/logout"),
                 securityContextPersistenceFilter,
                 logoutFilter,
-                new LogoutFilter("/", (x,c,v) -> {} )
+                new LogoutFilter("/", samlLogoutHandler)
         );
     }
 


### PR DESCRIPTION
## What
SP-initiated SAML logout (`user.mode=saml`) never ended the IdP session: `/logout`
cleared nothing and sent no SAML `LogoutRequest`, so the still-active IdP session
immediately re-authenticated the user.

## Cause
The `/logout` filter chain in `SamlSecurityConfig` wired the `LogoutFilter` with a
no-op `LogoutHandler`, so `SamlLogoutSuccessHandler` was never invoked.

## Fix
Wire `samlLogoutHandler` as the `LogoutFilter` handler — logout now clears the local
session and sends a SAML `LogoutRequest` to the IdP Single Logout Service.

## Tests
Keycloak (TestContainers) integration tests for the OAuth2 and SAML login→logout
lifecycle: `OAuthTest`, `SamlTest` (sharing `AbstractKeycloakTest`), with browser
emulation in `SsoBrowser`. Each verifies login, an authenticated session,
SP-initiated logout reaching the IdP, the local session cleared, and re-login required.

Fixes #1704
Jira: EPBDS-16182
