### PR TITLE
EPBDS-16224 Keep the <modules> block intact on Project Info and OpenAPI edits

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/ProjectBean.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/ProjectBean.java
@@ -30,6 +30,7 @@ import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Yaml;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.acls.domain.BasePermission;
 import org.springframework.stereotype.Service;
@@ -536,6 +537,7 @@ public class ProjectBean {
         ProjectDescriptor projectDescriptor = studio.getCurrentProjectDescriptor();
         projectDescriptor.setPropertiesFileNamePatterns(propertiesFileNamePatterns);
         ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(projectDescriptor);
+        keepDeclaredModules(newProjectDescriptor);
 
         Repository designRepository = currentProject.getDesignRepository();
         boolean supportsMappedFolders = designRepository != null && designRepository.supports().mappedFolders();
@@ -897,6 +899,7 @@ public class ProjectBean {
 
         ProjectDescriptor projectDescriptor = studio.getCurrentProjectDescriptor();
         ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(projectDescriptor);
+        keepDeclaredModules(newProjectDescriptor);
 
         clean(newProjectDescriptor);
 
@@ -917,6 +920,7 @@ public class ProjectBean {
 
         ProjectDescriptor projectDescriptor = studio.getCurrentProjectDescriptor();
         ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(projectDescriptor);
+        keepDeclaredModules(newProjectDescriptor);
 
         clean(newProjectDescriptor);
 
@@ -948,6 +952,7 @@ public class ProjectBean {
 
         ProjectDescriptor projectDescriptor = studio.getCurrentProjectDescriptor();
         ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(projectDescriptor);
+        keepDeclaredModules(newProjectDescriptor);
 
         clean(newProjectDescriptor);
 
@@ -964,6 +969,7 @@ public class ProjectBean {
 
         ProjectDescriptor projectDescriptor = studio.getCurrentProjectDescriptor();
         ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(projectDescriptor);
+        keepDeclaredModules(newProjectDescriptor);
         clean(newProjectDescriptor);
 
         String[] includeArray = StringUtils.toLines(exposedMethodIncludes);
@@ -1173,6 +1179,7 @@ public class ProjectBean {
 
         ProjectDescriptor projectDescriptor = studio.getCurrentProjectDescriptor();
         ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(projectDescriptor);
+        keepDeclaredModules(newProjectDescriptor);
         clean(newProjectDescriptor);
 
         String openAPIPathParam = FileNameFormatter
@@ -1542,6 +1549,7 @@ public class ProjectBean {
         validatePermissionsForDescriptorFile(currentProject, true);
 
         ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(currentProjectDescriptor);
+        keepDeclaredModules(newProjectDescriptor);
         clean(newProjectDescriptor);
         if (openAPIInfoChanged) {
             newProjectDescriptor.setOpenapi(openAPI);
@@ -1809,6 +1817,35 @@ public class ProjectBean {
         return Cloner.clone(projectDescriptor);
     }
 
+    /**
+     * Restores the modules declared in rules.xml on a descriptor that is about to be saved.
+     *
+     * <p>The resolved descriptor expands wildcard and auto-discovered modules into concrete files. When
+     * project information other than modules is edited, saving that descriptor would rewrite the modules
+     * block with those concrete files. Reading rules.xml as written keeps the block untouched. When
+     * rules.xml declares no modules, the block stays empty and is dropped on save.
+     */
+    private void keepDeclaredModules(ProjectDescriptor target) {
+        ProjectDescriptor declared;
+        try {
+            declared = ProjectDescriptor.read(studio.getCurrentProjectDescriptor().getProjectFolder());
+        } catch (Exception e) {
+            declared = null;
+        }
+        applyDeclaredModules(target, declared);
+    }
+
+    /**
+     * Copies the modules declared in rules.xml onto the descriptor about to be saved.
+     *
+     * <p>Leaves the target modules unchanged when rules.xml cannot be read.
+     */
+    static void applyDeclaredModules(ProjectDescriptor target, @Nullable ProjectDescriptor declared) {
+        if (declared != null) {
+            target.setModules(declared.getModules());
+        }
+    }
+
     public UIInput getPropertiesFileNameProcessorInput() {
         return propertiesFileNameProcessorInput;
     }
@@ -2034,10 +2071,22 @@ public class ProjectBean {
         var descriptor = studio.getCurrentProjectDescriptor();
         try {
             var originalDescriptor = ProjectDescriptor.read(descriptor.getProjectFolder());
-            return originalDescriptor != null ? originalDescriptor : descriptor;
+            return chooseModulesSource(originalDescriptor, descriptor);
         } catch (Exception e) {
             return descriptor;
         }
+    }
+
+    /**
+     * Chooses which descriptor supplies the modules shown on the Project Info screen.
+     *
+     * <p>Uses the modules declared in rules.xml when it declares any. When rules.xml declares no modules,
+     * or cannot be read, falls back to the resolved descriptor so the modules auto-discovered from the
+     * rules directory are still displayed.
+     */
+    static ProjectDescriptor chooseModulesSource(@Nullable ProjectDescriptor declared,
+                                                 ProjectDescriptor resolved) {
+        return declared != null && !declared.getModules().isEmpty() ? declared : resolved;
     }
 
     public void setCurrentModuleIndex(Integer currentModuleIndex) {

--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/ProjectBean.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/ProjectBean.java
@@ -1271,6 +1271,7 @@ public class ProjectBean {
                 }
             }
             ProjectDescriptor newProjectDescriptor = cloneProjectDescriptor(currentDescriptor);
+            keepDeclaredModules(newProjectDescriptor);
             clean(newProjectDescriptor);
             if (update && newProjectDescriptor.getOpenapi() != null) {
                 OpenAPI openAPI = newProjectDescriptor.getOpenapi();

--- a/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/webstudio/web/ProjectBeanDeclaredModulesTest.java
+++ b/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/webstudio/web/ProjectBeanDeclaredModulesTest.java
@@ -66,6 +66,24 @@ class ProjectBeanDeclaredModulesTest {
         assertEquals(2, target.getModules().size());
     }
 
+    @Test
+    void applyDeclaredModulesRestoresWildcardWhenOpenApiGenerationAddedModules() {
+        // OpenAPI file generation (createOrUpdateOpenAPISchema) clones the resolved descriptor - whose
+        // wildcard is expanded into concrete files - and may append generated model/algorithm modules.
+        // Saving must restore the declared wildcard so the <modules> block is not rewritten with the
+        // expanded/generated files.
+        var target = createProject("target",
+                createModule("rules/A.xlsx"),
+                createModule("rules/B.xlsx"),
+                createModule("rules/Generated.xlsx"));
+        var declared = createProject("declared", createModule("rules/*.xlsx"));
+
+        ProjectBean.applyDeclaredModules(target, declared);
+
+        assertEquals(1, target.getModules().size());
+        assertEquals("rules/*.xlsx", target.getModules().getFirst().getRulesRootPath());
+    }
+
     private static ProjectDescriptor createProject(String name, Module... modules) {
         var pd = new ProjectDescriptor();
         pd.setName(name);

--- a/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/webstudio/web/ProjectBeanDeclaredModulesTest.java
+++ b/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/webstudio/web/ProjectBeanDeclaredModulesTest.java
@@ -1,0 +1,82 @@
+package org.openl.rules.webstudio.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.openl.rules.project.model.Module;
+import org.openl.rules.project.model.ProjectDescriptor;
+
+class ProjectBeanDeclaredModulesTest {
+
+    @Test
+    void chooseModulesSourceUsesDeclaredWhenItHasModules() {
+        var declared = createProject("declared", createModule("Rules"));
+        var resolved = createProject("resolved", createModule("A"), createModule("B"));
+
+        assertSame(declared, ProjectBean.chooseModulesSource(declared, resolved));
+    }
+
+    @Test
+    void chooseModulesSourceFallsBackToResolvedWhenDeclaredHasNoModules() {
+        var declared = createProject("declared");
+        var resolved = createProject("resolved", createModule("A"), createModule("B"));
+
+        assertSame(resolved, ProjectBean.chooseModulesSource(declared, resolved));
+    }
+
+    @Test
+    void chooseModulesSourceFallsBackToResolvedWhenDeclaredIsMissing() {
+        var resolved = createProject("resolved", createModule("A"));
+
+        assertSame(resolved, ProjectBean.chooseModulesSource(null, resolved));
+    }
+
+    @Test
+    void applyDeclaredModulesReplacesTargetModulesWithDeclaredOnes() {
+        var target = createProject("target", createModule("Expanded1"), createModule("Expanded2"));
+        var declared = createProject("declared", createModule("rules/**/*.xlsx"));
+
+        ProjectBean.applyDeclaredModules(target, declared);
+
+        assertEquals(1, target.getModules().size());
+        assertEquals("rules/**/*.xlsx", target.getModules().getFirst().getRulesRootPath());
+    }
+
+    @Test
+    void applyDeclaredModulesClearsTargetWhenDeclaredHasNoModules() {
+        var target = createProject("target", createModule("Expanded1"), createModule("Expanded2"));
+        var declared = createProject("declared");
+
+        ProjectBean.applyDeclaredModules(target, declared);
+
+        assertTrue(target.getModules().isEmpty());
+    }
+
+    @Test
+    void applyDeclaredModulesKeepsTargetWhenDeclaredIsMissing() {
+        var target = createProject("target", createModule("Expanded1"), createModule("Expanded2"));
+
+        ProjectBean.applyDeclaredModules(target, null);
+
+        assertEquals(2, target.getModules().size());
+    }
+
+    private static ProjectDescriptor createProject(String name, Module... modules) {
+        var pd = new ProjectDescriptor();
+        pd.setName(name);
+        pd.setModules(List.of(modules));
+        return pd;
+    }
+
+    private static Module createModule(String rulesRootPath) {
+        var module = new Module();
+        module.setName(rulesRootPath);
+        module.setRulesRootPath(rulesRootPath);
+        return module;
+    }
+}


### PR DESCRIPTION
Editing project information (name, sources, dependencies, exposed methods, OpenAPI configuration) or generating the OpenAPI file saved the *resolved* project descriptor, whose wildcard / auto-discovered modules are expanded into concrete per-file modules — rewriting the user's `<modules>` block in rules.xml.

**Fix:** restore the modules as declared in rules.xml before saving on every descriptor-writing path, including `createOrUpdateOpenAPISchema` (the "OpenAPI File Configuration → generate" action), which previously bypassed it. Also show auto-discovered modules on the Project Info screen when rules.xml declares none.

**Tests:** `ProjectBeanDeclaredModulesTest` covers the restore mechanism, including the OpenAPI-generation scenario (expanded + generated modules restored to the declared wildcard).