### PR TITLE
EPBDS-16228 Use the username for the git committer when the display name is blank

### DIFF
--- a/STUDIO/org.openl.rules.repository.git/src/org/openl/rules/repository/git/GitRepository.java
+++ b/STUDIO/org.openl.rules.repository.git/src/org/openl/rules/repository/git/GitRepository.java
@@ -340,7 +340,7 @@ public class GitRepository implements BranchRepository, RepositorySettingsAware,
                 .setMessage(formatComment(CommitType.SAVE, data))
                 .setOnly(fileInRepository)
                 .setNoVerify(noVerify)
-                .setCommitter(data.getAuthor().getDisplayName(),
+                .setCommitter(data.getAuthor().getName(),
                         Optional.ofNullable(data.getAuthor().getEmail()).orElse(""))
                 .call();
     }
@@ -378,7 +378,7 @@ public class GitRepository implements BranchRepository, RepositorySettingsAware,
                     .setMessage(formatComment(CommitType.DELETE, data))
                     .setOnly(name)
                     .setNoVerify(noVerify)
-                    .setCommitter(data.getAuthor().getDisplayName(),
+                    .setCommitter(data.getAuthor().getName(),
                             Optional.ofNullable(data.getAuthor().getEmail()).orElse(""))
                     .call();
             commitId = commit.getId().getName();
@@ -438,7 +438,7 @@ public class GitRepository implements BranchRepository, RepositorySettingsAware,
             RevCommit commit = git.commit()
                     .setMessage(formatComment(CommitType.SAVE, destData))
                     .setNoVerify(noVerify)
-                    .setCommitter(destData.getAuthor().getDisplayName(),
+                    .setCommitter(destData.getAuthor().getName(),
                             Optional.ofNullable(destData.getAuthor().getEmail()).orElse(""))
                     .call();
             commitId = commit.getId().getName();
@@ -1279,7 +1279,7 @@ public class GitRepository implements BranchRepository, RepositorySettingsAware,
             git.commit()
                     .setMessage(mergeMessage)
                     .setNoVerify(noVerify)
-                    .setCommitter(mergeAuthor.getDisplayName(), Optional.ofNullable(mergeAuthor.getEmail()).orElse(""))
+                    .setCommitter(mergeAuthor.getName(), Optional.ofNullable(mergeAuthor.getEmail()).orElse(""))
                     .call();
         }
     }
@@ -2311,7 +2311,7 @@ public class GitRepository implements BranchRepository, RepositorySettingsAware,
         CommitCommand commitCommand = git.commit()
                 .setNoVerify(noVerify)
                 .setMessage(formatComment(CommitType.SAVE, folderData))
-                .setCommitter(folderData.getAuthor().getDisplayName(),
+                .setCommitter(folderData.getAuthor().getName(),
                         Optional.ofNullable(folderData.getAuthor().getEmail()).orElse(""));
 
         return commitChangedFiles(commitCommand);
@@ -2403,7 +2403,7 @@ public class GitRepository implements BranchRepository, RepositorySettingsAware,
         CommitCommand conflictResolveCommit = git.commit()
                 .setNoVerify(noVerify)
                 .setMessage(mergeMessage)
-                .setCommitter(author.getDisplayName(), Optional.ofNullable(author.getEmail()).orElse(""));
+                .setCommitter(author.getName(), Optional.ofNullable(author.getEmail()).orElse(""));
 
         Status status = git.status().call();
 

--- a/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitMultiUserWorkTest.java
+++ b/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitMultiUserWorkTest.java
@@ -85,7 +85,7 @@ class GitMultiUserWorkTest {
         assertNotNull(result);
         assertEquals(path, result.getName());
         assertEquals("jsmith@email", result.getAuthor().getEmail());
-        assertEquals("John Smith", result.getAuthor().getDisplayName());
+        assertEquals("John Smith", result.getAuthor().getName());
         assertEquals("Comment for " + path, result.getComment());
         assertEquals(text.length(), result.getSize());
         assertNotNull(result.getModifiedAt());

--- a/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryLockTest.java
+++ b/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryLockTest.java
@@ -64,7 +64,7 @@ class GitRepositoryLockTest {
         assertNotNull(result);
         assertEquals(path, result.getName());
         assertEquals("jsmith@email", result.getAuthor().getEmail());
-        assertEquals("John Smith", result.getAuthor().getDisplayName());
+        assertEquals("John Smith", result.getAuthor().getName());
         assertEquals("Comment for " + path, result.getComment());
         assertEquals(text.length(), result.getSize());
         assertNotNull(result.getModifiedAt());

--- a/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryTest.java
+++ b/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryTest.java
@@ -310,6 +310,25 @@ class GitRepositoryTest {
     }
 
     @Test
+    void saveWithBlankDisplayName() throws IOException {
+        // Regression for EPBDS-16228: a blank user display name must not break the commit.
+        // The git committer name falls back to the username (UserInfo.getName()); otherwise an
+        // empty committer ident aborts the commit and, in Studio, leaves a project half-opened.
+        String path = "rules/project1/folder/file-blank-dn";
+        String text = "File with blank display name author";
+        FileData data = new FileData();
+        data.setName(path);
+        data.setComment("Comment for " + path);
+        data.setAuthor(new UserInfo("jdoe", "jdoe@email", ""));
+        FileData result = repo.save(data, IOUtils.toInputStream(text));
+
+        assertNotNull(result);
+        // The committer name persisted to git is the username, not the blank display name.
+        assertEquals("jdoe", result.getAuthor().getDisplayName());
+        assertEquals(text, readText(repo.read(path)));
+    }
+
+    @Test
     void saveFolder() throws IOException {
         List<FileItem> changes = Arrays.asList(
                 new FileItem("rules/project1/new-path/file4", IOUtils.toInputStream("Added")),

--- a/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryTest.java
+++ b/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryTest.java
@@ -156,21 +156,21 @@ class GitRepositoryTest {
 
         FileData file1 = getFileData(files, "rules/project1/file1");
         assertNotNull(file1);
-        assertEquals("User 1", file1.getAuthor().getDisplayName());
+        assertEquals("User 1", file1.getAuthor().getName());
         assertEquals("user1@email.to", file1.getAuthor().getEmail());
         assertEquals("Initial commit in test branch", file1.getComment());
         assertEquals(3, file1.getSize());
 
         FileData file2 = getFileData(files, "rules/project1/file2");
         assertNotNull(file2);
-        assertEquals("User 2", file2.getAuthor().getDisplayName());
+        assertEquals("User 2", file2.getAuthor().getName());
         assertEquals("user2@email.to", file2.getAuthor().getEmail());
         assertEquals("Second modification", file2.getComment());
         assertEquals(12, file2.getSize());
 
         FileData file3 = getFileData(files, "rules/project1/folder/file3");
         assertNotNull(file3);
-        assertEquals("User 2", file3.getAuthor().getDisplayName());
+        assertEquals("User 2", file3.getAuthor().getName());
         assertEquals("user2@email.to", file3.getAuthor().getEmail());
         assertEquals("Second modification", file3.getComment());
         assertEquals(9, file3.getSize());
@@ -201,7 +201,7 @@ class GitRepositoryTest {
 
         FileData file2Rev2 = find(files, "rules/project1/file2");
         assertEquals("Rules_2", file2Rev2.getVersion());
-        assertEquals("User 1", file2Rev2.getAuthor().getDisplayName());
+        assertEquals("User 1", file2Rev2.getAuthor().getName());
         assertEquals("user1@email.to", file2Rev2.getAuthor().getEmail());
         assertEquals("Initial commit in test branch", file2Rev2.getComment());
         assertEquals(6, file2Rev2.getSize(), "Expected file content: 'Hello!'");
@@ -219,7 +219,7 @@ class GitRepositoryTest {
 
         FileData file2Rev3 = find(files, "rules/project1/file2");
         assertEquals("Rules_3", file2Rev3.getVersion());
-        assertEquals("User 2", file2Rev3.getAuthor().getDisplayName());
+        assertEquals("User 2", file2Rev3.getAuthor().getName());
         assertEquals("user2@email.to", file2Rev3.getAuthor().getEmail());
         assertEquals("Second modification", file2Rev3.getComment());
         assertEquals(12, file2Rev3.getSize(), "Expected file content: 'Hello World!'");
@@ -232,21 +232,21 @@ class GitRepositoryTest {
     void check() throws IOException {
         FileData file1 = repo.check("rules/project1/file1");
         assertNotNull(file1);
-        assertEquals("User 1", file1.getAuthor().getDisplayName());
+        assertEquals("User 1", file1.getAuthor().getName());
         assertEquals("user1@email.to", file1.getAuthor().getEmail());
         assertEquals("Initial commit in test branch", file1.getComment());
         assertEquals(3, file1.getSize());
 
         FileData file2 = repo.check("rules/project1/file2");
         assertNotNull(file2);
-        assertEquals("User 2", file2.getAuthor().getDisplayName());
+        assertEquals("User 2", file2.getAuthor().getName());
         assertEquals("user2@email.to", file2.getAuthor().getEmail());
         assertEquals("Second modification", file2.getComment());
         assertEquals(12, file2.getSize());
 
         FileData file3 = repo.check("rules/project1/folder/file3");
         assertNotNull(file3);
-        assertEquals("User 2", file3.getAuthor().getDisplayName());
+        assertEquals("User 2", file3.getAuthor().getName());
         assertEquals("user2@email.to", file3.getAuthor().getEmail());
         assertEquals("Second modification", file3.getComment());
         assertEquals(9, file3.getSize());
@@ -254,7 +254,7 @@ class GitRepositoryTest {
         FileData project1 = repo.check("rules/project1");
         assertNotNull(project1);
         assertEquals("rules/project1", project1.getName());
-        assertEquals("User 2", project1.getAuthor().getDisplayName());
+        assertEquals("User 2", project1.getAuthor().getName());
         assertEquals("user2@email.to", project1.getAuthor().getEmail());
         assertEquals("Second modification", project1.getComment());
         assertEquals(FileData.UNDEFINED_SIZE, project1.getSize());
@@ -278,7 +278,7 @@ class GitRepositoryTest {
 
         assertNotNull(result);
         assertEquals(path, result.getName());
-        assertEquals("John Smith", result.getAuthor().getDisplayName());
+        assertEquals("John Smith", result.getAuthor().getName());
         assertEquals("jsmith@email", result.getAuthor().getEmail());
         assertEquals("Comment for rules/project1/folder/file4", result.getComment());
         assertEquals(text.length(), result.getSize());
@@ -324,7 +324,7 @@ class GitRepositoryTest {
 
         assertNotNull(result);
         // The committer name persisted to git is the username, not the blank display name.
-        assertEquals("jdoe", result.getAuthor().getDisplayName());
+        assertEquals("jdoe", result.getAuthor().getName());
         assertEquals(text, readText(repo.read(path)));
     }
 
@@ -485,12 +485,12 @@ class GitRepositoryTest {
 
         FileData v3 = repo.checkHistory("rules/project1", "Rules_3");
         assertEquals("Rules_3", v3.getVersion());
-        assertEquals("User 2", v3.getAuthor().getDisplayName());
+        assertEquals("User 2", v3.getAuthor().getName());
         assertEquals("user2@email.to", v3.getAuthor().getEmail());
 
         FileData v2 = repo.checkHistory("rules/project1", "Rules_2");
         assertEquals("Rules_2", v2.getVersion());
-        assertEquals("User 1", v2.getAuthor().getDisplayName());
+        assertEquals("User 1", v2.getAuthor().getName());
         assertEquals("user1@email.to", v2.getAuthor().getEmail());
 
         assertNull(repo.checkHistory("rules/project1", "Rules_1"));
@@ -515,7 +515,7 @@ class GitRepositoryTest {
         FileData copy = repo.copyHistory("rules/project1/file2", dest, "Rules_2");
         assertNotNull(copy);
         assertEquals("rules/project1/file2-copy", copy.getName());
-        assertEquals("John Smith", copy.getAuthor().getDisplayName());
+        assertEquals("John Smith", copy.getAuthor().getName());
         assertEquals("jsmith@email", copy.getAuthor().getEmail());
         assertEquals("Copy file 2", copy.getComment());
         assertEquals(6, copy.getSize());
@@ -529,7 +529,7 @@ class GitRepositoryTest {
         FileData project2 = repo.copyHistory("rules/project1", destProject, "Rules_2");
         assertNotNull(project2);
         assertEquals("rules/project2", project2.getName());
-        assertEquals("John Smith", project2.getAuthor().getDisplayName());
+        assertEquals("John Smith", project2.getAuthor().getName());
         assertEquals("jsmith@email", project2.getAuthor().getEmail());
         assertEquals("Copy of project1", project2.getComment());
         assertEquals(FileData.UNDEFINED_SIZE, project2.getSize());
@@ -703,7 +703,7 @@ class GitRepositoryTest {
                 assertEquals(resolveText, readText(remoteItem));
                 FileData remoteData = remoteItem.getData();
                 assertEquals(localData.getVersion(), remoteData.getVersion());
-                assertEquals("John Smith", remoteData.getAuthor().getDisplayName());
+                assertEquals("John Smith", remoteData.getAuthor().getName());
                 assertEquals("jsmith@email", remoteData.getAuthor().getEmail());
                 assertEquals(mergeMessage, remoteData.getComment());
 
@@ -864,7 +864,7 @@ class GitRepositoryTest {
                 assertEquals(resolveText, readText(remoteItem));
                 FileData remoteData = remoteItem.getData();
                 assertEquals(localData.getVersion(), remoteData.getVersion());
-                assertEquals("Jane Smith", remoteData.getAuthor().getDisplayName());
+                assertEquals("Jane Smith", remoteData.getAuthor().getName());
                 assertEquals("jasmith@email", remoteData.getAuthor().getEmail());
                 assertEquals(mergeMessage, remoteData.getComment());
 

--- a/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/LocalGitRepositoryTest.java
+++ b/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/LocalGitRepositoryTest.java
@@ -76,7 +76,7 @@ class LocalGitRepositoryTest {
         assertNotNull(result);
         assertEquals(path, result.getName());
         assertEquals("jsmith@email", result.getAuthor().getEmail());
-        assertEquals("John Smith", result.getAuthor().getDisplayName());
+        assertEquals("John Smith", result.getAuthor().getName());
         assertEquals("Comment for rules/project1/folder/file4", result.getComment());
         assertEquals(text.length(), result.getSize());
         assertNotNull(result.getModifiedAt());

--- a/STUDIO/org.openl.rules.repository/src/org/openl/rules/repository/api/UserInfo.java
+++ b/STUDIO/org.openl.rules.repository/src/org/openl/rules/repository/api/UserInfo.java
@@ -25,10 +25,6 @@ public class UserInfo {
         return email;
     }
 
-    public String getDisplayName() {
-        return displayName;
-    }
-
     public String getName() {
         return StringUtils.isNotBlank(displayName) ? displayName : username;
     }

--- a/STUDIO/org.openl.rules.webstudio/test/org/openl/studio/repositories/service/ZipProjectSaveStrategyTest.java
+++ b/STUDIO/org.openl.rules.webstudio/test/org/openl/studio/repositories/service/ZipProjectSaveStrategyTest.java
@@ -105,7 +105,7 @@ class ZipProjectSaveStrategyTest {
         assertEquals(BASE_RULES_LOCATION + "Project 1", actualData.getName());
         assertEquals("Bar", actualData.getComment());
         assertEquals("jsmith@email", actualData.getAuthor().getEmail());
-        assertEquals("John Smith", actualData.getAuthor().getDisplayName());
+        assertEquals("John Smith", actualData.getAuthor().getName());
         assertEquals(1, actualData.getAdditionalData().size());
         FileMappingData actualAddData = (FileMappingData) actualData.getAdditionalData().values().iterator().next();
         assertEquals(BASE_RULES_LOCATION + "Project 1", actualAddData.getExternalPath());
@@ -133,7 +133,7 @@ class ZipProjectSaveStrategyTest {
         assertEquals(BASE_RULES_LOCATION + "Project 1", actualData.getName());
         assertEquals("Bar", actualData.getComment());
         assertEquals("jsmith@email", actualData.getAuthor().getEmail());
-        assertEquals("John Smith", actualData.getAuthor().getDisplayName());
+        assertEquals("John Smith", actualData.getAuthor().getName());
         assertEquals(1, actualData.getAdditionalData().size());
         FileMappingData actualAddData = (FileMappingData) actualData.getAdditionalData().values().iterator().next();
         assertEquals(BASE_RULES_LOCATION + "Project 1", actualAddData.getExternalPath());
@@ -161,7 +161,7 @@ class ZipProjectSaveStrategyTest {
         assertEquals(BASE_RULES_LOCATION + "Project 1", actualData.getName());
         assertEquals("", actualData.getComment());
         assertEquals("jsmith@email", actualData.getAuthor().getEmail());
-        assertEquals("John Smith", actualData.getAuthor().getDisplayName());
+        assertEquals("John Smith", actualData.getAuthor().getName());
         assertEquals(0, actualData.getAdditionalData().size());
     }
 
@@ -187,7 +187,7 @@ class ZipProjectSaveStrategyTest {
         assertEquals(BASE_RULES_LOCATION + "Project 1", actualData.getName());
         assertEquals("Bar", actualData.getComment());
         assertEquals("jsmith@email", actualData.getAuthor().getEmail());
-        assertEquals("John Smith", actualData.getAuthor().getDisplayName());
+        assertEquals("John Smith", actualData.getAuthor().getName());
         assertEquals(1, actualData.getAdditionalData().size());
         FileMappingData actualAddData = (FileMappingData) actualData.getAdditionalData().values().iterator().next();
         assertEquals(BASE_RULES_LOCATION + "Project 1", actualAddData.getExternalPath());
@@ -226,7 +226,7 @@ class ZipProjectSaveStrategyTest {
         assertEquals(BASE_RULES_LOCATION + "Project 2", actualData.getName());
         assertEquals("Bar", actualData.getComment());
         assertEquals("jsmith@email", actualData.getAuthor().getEmail());
-        assertEquals("John Smith", actualData.getAuthor().getDisplayName());
+        assertEquals("John Smith", actualData.getAuthor().getName());
         assertEquals(1, actualData.getAdditionalData().size());
         FileMappingData actualAddData = (FileMappingData) actualData.getAdditionalData().values().iterator().next();
         assertEquals(BASE_RULES_LOCATION + "Project 2", actualAddData.getExternalPath());


### PR DESCRIPTION
## Problem

Opening a freshly uploaded design-repo project in single-user mode leaves it half-checked-out: `PATCH /rest/projects/{id}` with `{"status":"OPENED"}` returns 204 but the design project stays `CLOSED`, a duplicate `local`/`LOCAL` project appears, and `POST /rest/projects/{id}/tests/run` returns 409 `project.not.opened`. Reported as EPBDS-16228; reproduces on the current `webstudio:x` (6.3.1-SNAPSHOT) via pure REST.

## Root cause

The git committer name was taken from `UserInfo.getDisplayName()` (raw). When the display name is blank, that produces an empty git committer ident, which aborts the commit performed during project open; the half-completed checkout is left without its `.studioProps/.version` link and is treated as an independent `local` project instead of the working copy of the design project.

This is a latent defect since EPBDS-11274 (2021): `UserInfo` has always exposed both `getDisplayName()` (raw) and `getName()` (display name with **username fallback**), and the git layer used the raw one. It only became reachable when EPBDS-16213 made the single-user default `security.single.display-name` blank (and let users clear it via the profile UI). Bisect: parent `756c03b1` opens correctly; `3fa19b5232` (EPBDS-16213) is the first broken build.

## Why it is not single-user-specific

The git author is built the same way in every user mode (`RulesUserSession` → `new UserInfo(username, email, displayName)` → `GitRepository.setCommitter(...)`), and the display name is not validated as non-blank, so any user in any mode whose display name is blank (including one cleared via the profile UI) hits the same broken open. Fixing at the `UserInfo`/git layer covers all modes.

## Fix

Make `getName()` (display name with username fallback) the single name accessor and remove `UserInfo.getDisplayName()` entirely, so no caller — in any mode — can pass a raw, possibly-empty display name to the git committer. All call sites use `getName()`.

## Verification

- Full-reactor `clean test-compile` passes (no remaining `getDisplayName()` references).
- `org.openl.rules.repository.git` + `org.openl.rules.repository` tests pass (84), incl. a new regression test `GitRepositoryTest#saveWithBlankDisplayName`.
- Webstudio `ZipProjectSaveStrategyTest`, `UsersControllerTest`, `SingleUserModeInitTest`, `UserManagementTest` pass (22).
- End-to-end on the default (blank display name) image: `PATCH` → `OPENED`, no duplicate, `tests/run` → 202.