### PR TITLE
EPBDS-16227 Keep implicit modules when adding or copying an Excel module

### DIFF
--- a/DEV/org.openl.rules.project/src/org/openl/rules/project/ProjectDescriptorManager.java
+++ b/DEV/org.openl.rules.project/src/org/openl/rules/project/ProjectDescriptorManager.java
@@ -1,14 +1,23 @@
 package org.openl.rules.project;
 
+import java.util.List;
+
 import org.openl.rules.project.model.Module;
 import org.openl.rules.project.model.ProjectDescriptor;
 import org.openl.util.FileUtils;
 
 public class ProjectDescriptorManager {
 
+    /**
+     * Tells whether a module path is already matched by a wildcard module of the project.
+     *
+     * <p>When rules.xml declares no modules, the project relies on the implicit default modules
+     * ({@link ProjectDescriptor#defaultModules()}), so those are checked instead of the empty declared list. A file
+     * under {@code rules/} or {@code tests/} is therefore reported as covered even when rules.xml has no modules.
+     */
     public boolean isCoveredByWildcardModule(ProjectDescriptor descriptor, Module otherModule) {
         final String otherModuleRootPath = otherModule.getRulesRootPath();
-        for (Module module : descriptor.getModules()) {
+        for (Module module : effectiveModules(descriptor)) {
             if (module.isModuleWithWildcard() && otherModuleRootPath != null) {
                 String relativePath = otherModuleRootPath.replace("\\", "/");
                 if (FileUtils.pathMatches(module.getRulesRootPath(), relativePath)) {
@@ -17,6 +26,31 @@ public class ProjectDescriptorManager {
             }
         }
         return false;
+    }
+
+    /**
+     * Registers a new module in the descriptor while preserving the modules auto-discovered when rules.xml declares
+     * none.
+     *
+     * <p>Adds nothing when the file is already matched by a wildcard module, so it stays auto-discovered and the
+     * declared module list is left empty.
+     *
+     * <p>Otherwise appends the module. When rules.xml declares no modules, the implicit default modules are
+     * materialized first so adding one explicit module does not hide them.
+     */
+    public void registerModule(ProjectDescriptor descriptor, Module module) {
+        if (isCoveredByWildcardModule(descriptor, module)) {
+            return;
+        }
+        if (descriptor.getModules().isEmpty()) {
+            descriptor.getModules().addAll(ProjectDescriptor.defaultModules());
+        }
+        descriptor.getModules().add(module);
+    }
+
+    private static List<Module> effectiveModules(ProjectDescriptor descriptor) {
+        var modules = descriptor.getModules();
+        return modules.isEmpty() ? ProjectDescriptor.defaultModules() : modules;
     }
 
 }

--- a/DEV/org.openl.rules.project/src/org/openl/rules/project/model/ProjectDescriptor.java
+++ b/DEV/org.openl.rules.project/src/org/openl/rules/project/model/ProjectDescriptor.java
@@ -391,14 +391,31 @@ public class ProjectDescriptor {
         return this;
     }
 
+    /**
+     * Path patterns for the modules discovered when rules.xml declares none: every Excel file under the
+     * {@code rules/} and {@code tests/} directories.
+     */
+    private static final List<String> DEFAULT_MODULE_PATHS = List.of("rules/**/*.xlsx", "tests/**/*.xlsx");
+
+    /**
+     * Returns the modules discovered by default when rules.xml declares no modules.
+     *
+     * <p>These cover every Excel file under the {@code rules/} and {@code tests/} directories.
+     *
+     * <p>Each call returns fresh {@link Module} instances, so callers may modify or persist them freely.
+     */
+    public static List<Module> defaultModules() {
+        return DEFAULT_MODULE_PATHS.stream().map(path -> {
+            var module = new Module();
+            module.setRulesRootPath(path);
+            return module;
+        }).toList();
+    }
+
     private void fillModulesByPattern() throws IOException {
         var readModules = getModules();
         if (readModules.isEmpty()) {
-            var rules = new Module();
-            rules.setRulesRootPath("rules/**/*.xlsx");
-            var tests = new Module();
-            tests.setRulesRootPath("tests/**/*.xlsx");
-            readModules = Arrays.asList(rules, tests);
+            readModules = defaultModules();
         }
         var processedModules = new ArrayList<Module>(readModules.size());
         // Process modules without wildcard path

--- a/DEV/org.openl.rules.project/test/org/openl/rules/project/ProjectDescriptorManagerTest.java
+++ b/DEV/org.openl.rules.project/test/org/openl/rules/project/ProjectDescriptorManagerTest.java
@@ -1,14 +1,18 @@
 package org.openl.rules.project;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.openl.rules.project.model.Module;
 import org.openl.rules.project.model.ProjectDescriptor;
@@ -41,6 +45,97 @@ class ProjectDescriptorManagerTest {
 
         newModule.setRulesRootPath("New Module.xlsx");
         assertFalse(manager.isCoveredByWildcardModule(descriptor, newModule));
+    }
+
+    @Test
+    void emptyDescriptorIsCoveredByImplicitDefaults() {
+        ProjectDescriptorManager manager = new ProjectDescriptorManager();
+        ProjectDescriptor descriptor = new ProjectDescriptor();
+
+        // A project with no declared modules relies on the implicit rules/** and tests/** defaults.
+        assertTrue(manager.isCoveredByWildcardModule(descriptor, module("rules/New Module.xlsx")));
+        assertTrue(manager.isCoveredByWildcardModule(descriptor, module("tests/New Module.xlsx")));
+        assertFalse(manager.isCoveredByWildcardModule(descriptor, module("New Module.xlsx")));
+    }
+
+    @Test
+    void registerModuleUnderRulesKeepsModulesImplicit() {
+        ProjectDescriptorManager manager = new ProjectDescriptorManager();
+        ProjectDescriptor descriptor = new ProjectDescriptor();
+
+        manager.registerModule(descriptor, module("rules/New Module.xlsx"));
+
+        // The file is auto-discovered, so nothing is written and the other implicit modules survive.
+        assertTrue(descriptor.getModules().isEmpty());
+    }
+
+    @Test
+    void registerModuleInRootMaterializesImplicitDefaults() {
+        ProjectDescriptorManager manager = new ProjectDescriptorManager();
+        ProjectDescriptor descriptor = new ProjectDescriptor();
+
+        manager.registerModule(descriptor, module("New Module.xlsx"));
+
+        // A root file is not auto-discovered, so the implicit defaults are materialized before appending it.
+        assertEquals(List.of("rules/**/*.xlsx", "tests/**/*.xlsx", "New Module.xlsx"),
+                descriptor.getModules().stream().map(Module::getRulesRootPath).toList());
+    }
+
+    @Test
+    void registerModuleCoveredByDeclaredWildcardAddsNothing() throws Exception {
+        ProjectDescriptorManager manager = new ProjectDescriptorManager();
+        ProjectDescriptor descriptor = ProjectDescriptor.read(Path.of("test-resources/descriptor/rules-wildcard.xml"));
+
+        manager.registerModule(descriptor, module("rules/New Module.xlsx"));
+
+        assertEquals(2, descriptor.getModules().size());
+    }
+
+    @Test
+    void addingFileUnderRulesKeepsAllModules(@TempDir Path projectFolder) throws Exception {
+        Files.createDirectories(projectFolder.resolve("rules"));
+        Files.createFile(projectFolder.resolve("rules/BugReproducing.xlsx"));
+        Files.createFile(projectFolder.resolve("rules/generalProject.xlsx"));
+
+        ProjectDescriptor descriptor = new ProjectDescriptor();
+        descriptor.setProjectFolder(projectFolder);
+
+        // Simulate adding a new Excel file under rules/ to a project that declares no modules.
+        Files.createFile(projectFolder.resolve("rules/context_bug.xlsx"));
+        new ProjectDescriptorManager().registerModule(descriptor, module("context_bug", "rules/context_bug.xlsx"));
+
+        assertEquals(List.of("BugReproducing", "context_bug", "generalProject"), resolvedModuleNames(descriptor));
+    }
+
+    @Test
+    void addingFileInRootKeepsImplicitModules(@TempDir Path projectFolder) throws Exception {
+        Files.createDirectories(projectFolder.resolve("rules"));
+        Files.createFile(projectFolder.resolve("rules/BugReproducing.xlsx"));
+        Files.createFile(projectFolder.resolve("rules/generalProject.xlsx"));
+
+        ProjectDescriptor descriptor = new ProjectDescriptor();
+        descriptor.setProjectFolder(projectFolder);
+
+        // Simulate adding a new Excel file in the project root, which the implicit defaults do not match.
+        Files.createFile(projectFolder.resolve("context_bug.xlsx"));
+        new ProjectDescriptorManager().registerModule(descriptor, module("context_bug", "context_bug.xlsx"));
+
+        assertEquals(List.of("BugReproducing", "context_bug", "generalProject"), resolvedModuleNames(descriptor));
+    }
+
+    private static List<String> resolvedModuleNames(ProjectDescriptor descriptor) throws IOException {
+        return descriptor.expand().getModules().stream().map(Module::getName).sorted().toList();
+    }
+
+    private static Module module(String rulesRootPath) {
+        return module("New Module", rulesRootPath);
+    }
+
+    private static Module module(String name, String rulesRootPath) {
+        Module module = new Module();
+        module.setName(name);
+        module.setRulesRootPath(rulesRootPath);
+        return module;
     }
 
     private static FileSystem openZipFile(Path path) throws IOException {

--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/ProjectBean.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/ProjectBean.java
@@ -593,12 +593,12 @@ public class ProjectBean {
         Module module;
 
         boolean moduleWasRenamed = false;
+        boolean addNewModule = StringUtils.isBlank(oldName) && StringUtils.isBlank(index);
 
-        if (StringUtils.isBlank(oldName) && StringUtils.isBlank(index)) {
-            // Add new Module
+        if (addNewModule) {
+            // Add new Module - registered after its path is known so implicit modules are preserved
             module = new Module();
             module.setProject(newProjectDescriptor);
-            newProjectDescriptor.getModules().add(module);
         } else {
             // Edit current Module
             if (!StringUtils.isBlank(oldName)) {
@@ -652,6 +652,10 @@ public class ProjectBean {
             }
             module.setWebstudioConfiguration(webstudioConfiguration);
 
+            if (addNewModule) {
+                projectDescriptorManager.registerModule(newProjectDescriptor, module);
+            }
+
             clean(newProjectDescriptor);
             save(newProjectDescriptor);
         }
@@ -702,7 +706,7 @@ public class ProjectBean {
         if (!moduleMatchesSomePathPattern) {
             // Add new Module
             newModule.setProject(newProjectDescriptor);
-            newProjectDescriptor.getModules().add(newModule);
+            projectDescriptorManager.registerModule(newProjectDescriptor, newModule);
 
             clean(newProjectDescriptor);
             save(newProjectDescriptor);

--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/repository/RepositoryTreeController.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/repository/RepositoryTreeController.java
@@ -1803,10 +1803,7 @@ public class RepositoryTreeController {
                     Module module = new Module();
                     module.setName(FileUtils.getBaseName(fileName));
                     module.setRulesRootPath(modulePath);
-                    ProjectDescriptorManager descriptorManager = new ProjectDescriptorManager();
-                    if (!descriptorManager.isCoveredByWildcardModule(projectDescriptor, module)) {
-                        projectDescriptor.getModules().add(module);
-                    }
+                    new ProjectDescriptorManager().registerModule(projectDescriptor, module);
                     resource.setContent(new ByteArrayInputStream(projectDescriptor.toBytes()));
                 }
             } catch (ProjectException ex) {


### PR DESCRIPTION
A project with an empty <modules> block relies on the implicit default modules (rules/**/*.xlsx and tests/**/*.xlsx) that ProjectDescriptor.fillModulesByPattern applies only for an empty declared list. Adding or copying an Excel file re-read the raw rules.xml, appended a single explicit <module>, and rewrote the file, so the next resolve skipped the implicit defaults and every auto-discovered module disappeared from the panel.

Share the implicit defaults through ProjectDescriptor.defaultModules(), make ProjectDescriptorManager.isCoveredByWildcardModule treat an empty declared list as covered by those defaults, and add registerModule which keeps <modules> empty for auto-discovered files and materializes the defaults before appending a file the defaults do not match. Route the add-file, copy-module, and add-module write paths through it.