### PR TITLE
Fix OutOfMemoryError crashes of the webstudio test fork

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/pom.xml
+++ b/STUDIO/org.openl.rules.webstudio/pom.xml
@@ -17,6 +17,13 @@
     </organization>
     <properties>
         <sonar.sources>src,webapp</sonar.sources>
+        <!-- One fork runs the whole suite and outgrows the inherited caps: the perf heap kills the fork
+             mid-suite, and the live class metadata of the full application stack loaded across the suite
+             (~157M measured at 976 tests, nothing leaking) overflows the Metaspace cap at the very end.
+             Both modes deliberately share the smallest CI-validated envelope: a tighter perf value is an
+             untested guess that risks turning the nightly Build red again. -->
+        <surefire.argLine.noPerf>-Xms8m -Xmx128m -Xss256k -XX:MaxMetaspaceSize=256m</surefire.argLine.noPerf>
+        <surefire.argLine.perf>-Xms8m -Xmx128m -Xss256k -XX:MaxMetaspaceSize=256m</surefire.argLine.perf>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Problem

The `org.openl.rules.webstudio` test suite (976 tests) runs in a single surefire fork and has outgrown the surefire memory caps inherited from the root pom:

- **Weekly nightly Build on `main` is red**: in perf mode (`-Xmx61m`) the fork dies mid-suite with `OutOfMemoryError: Java heap space` on the ubuntu and macos legs (nightlies of Jul 15 and Jul 22).
- **Local `-DnoPerf` runs fail**: the fork dies with `OutOfMemoryError: Metaspace` right after the last test passes (`-XX:MaxMetaspaceSize=160m`), producing `BUILD FAILURE` although all tests are green.
- The per-push **tests** job never showed either failure because `-Psonar` clears `surefire.argLine`, so coverage runs have no memory caps at all.

## Diagnostics (JVM unified logging on CI, Java 21)

- Peak metaspace is **~157 MB of live class metadata** — the old 160m cap ran at 98% utilization, so pass vs. OOM depended on the machine.
- The metadata is the live union of the full application stack loaded across the suite (Hibernate 4.6k classes, JDK 4.4k, OpenL 3.9k, Spring 2.9k, POI/CXF 2.1k, ByteBuddy/Mockito 1.7k, Jackson 0.9k, other ~5k). Only ~1% of classes are transient.
- **No leak**: OpenL per-compilation generated classes unload correctly (23 loaded / 20 unloaded), LambdaForms unload too.
- Trimming the Spring test context cache (`spring.test.context.cache.maxSize=1`) moves peak metaspace by +0.2 MB — context-caching hygiene cannot fix this ceiling.

## Change

Override both surefire argLines for this module only, following the existing per-module pattern (`repository.git`, `xls.merge`, `itest.studio`, …): heap `-Xmx128m` in both modes, `-XX:MaxMetaspaceSize=256m`.

## Verification (scoped Build dispatches on this branch)

- `-DnoPerf` ([run #1963](https://github.com/openl-tablets/openl-tablets/actions/runs/29995889023)): green on ubuntu 21/25, macos 21/25/26.
- perf mode ([run #1964](https://github.com/openl-tablets/openl-tablets/actions/runs/29997497991)): green on ubuntu/windows/macos × Java 21/25.
- Java 26 x64 legs fail on a pre-existing `OpenLTest.testAll` issue in `org.openl.rules.test` (upstream of this module, unrelated; macos/aarch64 Java 26 is green).

## Related pre-existing issues (not addressed here)

- Windows nightly legs fail earlier on `spotless:check` (CRLF in `ITEST/itest.smoke/**/*.groovy` after Windows checkout).
- `-Psonar` clearing `surefire.argLine` leaves coverage runs uncapped.
- `OpenLTest.testAll` fails on Java 26 x64 (ubuntu/windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtqAbQNaDEKsVGntkdYATv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtqAbQNaDEKsVGntkdYATv)_