### PR TITLE
Remove dead code in studio-ui trace styles

### DIFF
--- a/STUDIO/studio-ui/src/containers/TraceView/components/TraceDetails.styles.ts
+++ b/STUDIO/studio-ui/src/containers/TraceView/components/TraceDetails.styles.ts
@@ -12,12 +12,6 @@ export const useStyles = createStyles(({ css, token }) => ({
         align-items: center;
         justify-content: center;
     `,
-    tableHeader: css`
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: ${token.marginXS}px;
-    `,
     frameTitle: css`
         font-weight: 600;
         font-size: ${token.fontSizeLG}px;


### PR DESCRIPTION
Daily dead-code sweep. One removal this run — the Maven-free veins are close to exhausted (see "Why this run is small").

## What was removed

**`Remove the unused tableHeader style from the trace details panel`** — 6 lines, `TraceDetails.styles.ts`.

The `tableHeader` key of the `createStyles` object in
`STUDIO/studio-ui/src/containers/TraceView/components/TraceDetails.styles.ts` is applied to nothing.

### Evidence

- `grep -rIn 'tableHeader' .` (whole repository, all file types, excluding `target/`, `node_modules/`, `.git/`)
  returns exactly one hit inside studio-ui: the key's own definition. Every other hit is an unrelated Java
  identifier in `DEV/`, `Util/` and `webstudio`, plus the `tableHeader` input id in `searchForm.xhtml` — none of
  them a CSS-in-JS class consumer.
- `TraceDetails.styles.ts` is imported by exactly one file, `TraceDetails.tsx`, and that file reaches style keys
  only through static property access (`styles.details`, `cx(styles.swatch, styles.swatchCurrent)`, …). It never
  indexes `styles` with a computed key, so the full-text search is conclusive for this file.
- A generated CSS-in-JS class name cannot be referenced from outside the bundle: `antd-style` hashes it at runtime,
  so no JSF page, Java string or stylesheet can name it.

### Method

The candidate came from a scan of all 537 top-level `createStyles` keys across the module's 23 `*.styles.ts` files
and inline `createStyles` calls. `tableHeader` was the only key with zero references. Four components —
`FileChangeIcon`, `TraceTree`, `TraceTableView` and `FillTagsModal` — index their style objects with a computed key,
so their style files were excluded from candidacy entirely rather than trusted to a name search.

## How it was verified

Run in `STUDIO/studio-ui` after the removal:

- `npx tsc --noEmit` — clean
- `npx eslint ./src` — clean
- `npx vitest run` — 141 test files, 1123 tests, all passing (matches the pre-change baseline)

`mvn validate -N` could not run; see below.

## Why this run is small

No Maven goal can run in the sweep container. The root `pom.xml` imports `org.opensaml:opensaml-bom:5.2.3`, which is
published only on `build.shibboleth.net`; that host is refused with HTTP 403 by the environment's egress policy, and
Maven Central answers 404. The root POM therefore cannot be read, which kills every goal including `mvn validate -N`.
Java and resource removals that need a compile gate are off the table until a human lifts that policy, so this run was
limited to what the Node toolchain can verify on its own.

Veins checked this run that came up empty, so a reviewer knows they were not skipped:

- **`package.json` dependencies** — all 24 runtime and all 22 dev dependencies are genuinely referenced. Nothing to remove.
- **i18n locale keys** — not provable, and correctly left alone. Roughly 1156 literal `t('…')` calls coexist with many
  dynamic ones (`t(\`browser.files.change.${change.type}\`)`, `t(meta.labelKey)`, `t(activeMethod.descKey)`), so a name
  search cannot clear a key.
- **Locale namespaces** — all 15 registered bundles are used.
- **Enum members** — no zero-reference members across the module.
- **`Props` interface members** — no zero-reference members across the module.
- **`public/` assets** — all live; the two android-chrome icons are named by `site.webmanifest`.
- **`org.openl.rules.tableeditor` bundles** — every CSS and JS source is present in the `compile.css.sh` /
  `compile.js.sh` concat lists, so nothing is orphaned there.
- **`org.openl.rules.webstudio` web resources** — a fresh whole-file scan produced five zero-basename-reference
  `.xhtml` pages, and four turned out alive: `run`, `benchmark`, `changes` and `copyTable` are all reached through
  `studio.url('…')`, which drops the extension. Only the extension-less search caught them.

## Deliberately kept or deferred

- **`webapp/pages/modules/revisions.xhtml`** — very likely React-migration residue: nothing links to it, no
  `studio.url('revisions')` exists, and `containers/projects/OpenRevisionModal.tsx` now does the same job. It is
  **not** removed here because removal would strand three members of `WebStudio.java` that only this page consumes —
  `getProjectVersions()`, `setProjectVersion(String)` and the `canOpenOtherVersion` property. Page and Java members
  belong in one commit, and Java cannot be compiled in this container. Left for a run that can build.
- **`public/icons/site.webmanifest`** names `android-chrome-512x512.pngs` — note the trailing `s`. The 512px icon
  ships but is unreachable through the manifest. That is a one-character bug, not dead code, and this sweep only
  deletes, so it is reported rather than fixed.
- Standing keep-list respected: `rf-*` selectors, `jquery-migrate` and its `.selector` shim, `META-INF/services/**`,
  `cache2k.xml`, `resources/logging.properties`, the tableeditor taglib and its `compile.*` scripts, and icons
  referenced by literal path.
- `Util/openl-maven-plugin` resources are all under `it/` — Maven-invoker integration-test fixtures, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8xtyvtLHLGcZ6BFkmrV94)_