### PR TITLE
Update npm dependencies

### DIFF
--- a/STUDIO/studio-ui/package-lock.json
+++ b/STUDIO/studio-ui/package-lock.json
@@ -48,7 +48,7 @@
         "eslint": "^10.8.0",
         "eslint-plugin-perfectionist": "^5.10.0",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "globals": "^17.7.0",
+        "globals": "^17.8.0",
         "jsdom": "^29.1.1",
         "license-checker-rseidelsohn": "^5.0.1",
         "typescript": "^6.0.3",
@@ -4755,9 +4755,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/STUDIO/studio-ui/package.json
+++ b/STUDIO/studio-ui/package.json
@@ -49,7 +49,7 @@
     "eslint": "^10.8.0",
     "eslint-plugin-perfectionist": "^5.10.0",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "jsdom": "^29.1.1",
     "license-checker-rseidelsohn": "^5.0.1",
     "typescript": "^6.0.3",


### PR DESCRIPTION
Weekly npm dependency sweep of `STUDIO/studio-ui`. `npm-check-updates` (majors included) found only two
candidates this week; one landed, one is blocked upstream.

Toolchain used matches CI (`frontend-maven-plugin`: `node.version` / `npm.version` in the root `pom.xml`):
Node v24.18.0, npm 12.0.1. `engines` is untouched.

## Upgraded

| Package | Old | New | Major |
| --- | --- | --- | --- |
| `globals` | `^17.7.0` | `^17.8.0` | no (minor) |

## Skipped

- **`typescript`** — attempted `^7.0.2` (major), **failed gate 3 (`npm run lint`)**.
  `@typescript-eslint/parser` refuses to load and aborts ESLint outright:

  ```
  Error: typescript-eslint does not support TS 7.0.
  ```

  The peer graph states it too — `@typescript-eslint` 8.65.0 (the latest release) declares
  `typescript: ">=4.8.4 <6.1.0"`, so `npm install` resolved TS 7 only by overriding that peer and marking
  every `@typescript-eslint/*` node `invalid`. Notably `npm run typecheck` *passes* on TS 7 — the blocker is
  purely the lint toolchain. No `--force`, `--legacy-peer-deps`, or `overrides` entry was used to get around
  it, and the lockfile was regenerated from a clean slate afterwards so no nested duplicates from the attempt
  remain. `^6.0.3` is already the newest version the peer range allows (only 6.0.2 and 6.0.3 exist on the 6.x
  line), so TypeScript stays put.

  Upstream: [TypeScript 7.0 announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0)
  · [typescript-eslint TS >=7.1 support tracking issue](https://github.com/typescript-eslint/typescript-eslint/issues/10940).
  Re-attempt once `typescript-eslint` ships TS 7 support.

- **`react-router-dom`** — *not* an upgrade candidate and no gate failed; recorded here because `npm audit`
  reports 2 high-severity findings that this sweep deliberately does not act on.
  `react-router-dom@7.18.1` is the newest version published and it pins `react-router@7.18.1`, which falls
  inside the advisory range `7.12.0 - 8.2.0`
  ([GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2), RSC-mode CSRF bypass). The fix
  exists only in `react-router` 8.3.0, and the 8.x line dropped the `-dom` package entirely — so consuming it
  means migrating the app off `react-router-dom` onto `react-router` v8. That is a framework major migration,
  well beyond a renamed prop or a moved import, so it is out of scope here and wants its own ticket.
  `npm audit fix --force` was not run: it would *downgrade* to `react-router-dom@7.11.0`.

## Migrations

None. No file under `src/**` was touched — this pull request changes only `STUDIO/studio-ui/package.json`
and `STUDIO/studio-ui/package-lock.json`.

## Verification

All five gates were run in order from `STUDIO/studio-ui`, sequentially, on the final committed state
(nothing heavy running alongside vitest):

| # | Gate | Outcome |
| --- | --- | --- |
| 1 | `rm -rf node_modules && npm ci` | pass — 539 packages added, 540 audited, lockfile installs clean from scratch and stays unmodified |
| 2 | `npm run typecheck` | pass — `tsc --noEmit`, no diagnostics |
| 3 | `npm run lint` | pass — `eslint ./src`, no findings |
| 4 | `npm run build` | pass — licence check against `MIT;Apache-2.0;BSD-3-Clause;ISC;0BSD` clean (no new licence introduced), `vite build` succeeded, 3523 modules transformed |
| 5 | `npm run test` | pass — **143/143 test files, 1154/1154 tests passed**, 0 failed, 0 skipped, 140.44s |

Coverage from the same run: statements 88.09%, branches 79.39%, functions 82.98%, lines 88.97%.

> [!Note]
> `mvn validate -N` could not be executed in the sweep container: the root `pom.xml` imports
> `org.opensaml:opensaml-bom:5.2.3`, published only on `build.shibboleth.net`, which the container's egress
> policy refuses with HTTP 403 — a pre-existing environmental limit unrelated to this change. Both changed
> files were instead verified directly: valid JSON, LF endings, 2-space indent per `.editorconfig`
> (`[*.json] indent_size = 2`), and `git diff --check` reports no whitespace errors. No Java, XML, or
> mirrored-version file is touched, so the Spotless and mirrored-version checks have nothing to act on here.
> GitHub Actions remains the authoritative gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_0129Li7XAtNwMeeNhS3b6yzP)_