### PR TITLE
Remove unused dependency declarations and never-read writes across Util, DEV, STUDIO and WSFrontend

### DIFF
--- a/DEV/org.openl.rules.project/src/org/openl/rules/project/model/ProjectDescriptor.java
+++ b/DEV/org.openl.rules.project/src/org/openl/rules/project/model/ProjectDescriptor.java
@@ -145,7 +145,7 @@ public class ProjectDescriptor {
                 String file = projectUrl.getPath();
                 // jar URLs must be ended with '!/' or '/' for proper URLClassLoader work
                 if (!file.endsWith("/")) {
-                    String suffix = null;
+                    String suffix;
                     if (file.contains("!/")) {
                         // we are inside jar/zip file like: jar:///file.zip!/project
                         // so needs to add '/' to the end

--- a/STUDIO/org.openl.rules.project.openapi/pom.xml
+++ b/STUDIO/org.openl.rules.project.openapi/pom.xml
@@ -30,9 +30,5 @@
             <groupId>org.openl.rules</groupId>
             <artifactId>org.openl.rules.jackson</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.openl.rules</groupId>
-            <artifactId>org.openl.rules.test</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/STUDIO/org.openl.rules.project.validation.openapi/pom.xml
+++ b/STUDIO/org.openl.rules.project.validation.openapi/pom.xml
@@ -24,10 +24,6 @@
         <!-- OpenL dependencies -->
         <dependency>
             <groupId>org.openl.rules</groupId>
-            <artifactId>org.openl.rules.project.openapi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openl.rules</groupId>
             <artifactId>org.openl.rules.ruleservice.ws.common</artifactId>
         </dependency>
         <dependency>

--- a/STUDIO/org.openl.rules.project.validation.openapi/test/org/openl/rules/project/validation/openapi/test/ServiceExtraMethodHandlerImpl.java
+++ b/STUDIO/org.openl.rules.project.validation.openapi/test/org/openl/rules/project/validation/openapi/test/ServiceExtraMethodHandlerImpl.java
@@ -31,7 +31,6 @@ public class ServiceExtraMethodHandlerImpl implements ServiceExtraMethodHandler<
         } else if (this.getClass() != var1.getClass()) {
             return false;
         } else {
-            ServiceExtraMethodHandlerImpl var2 = (ServiceExtraMethodHandlerImpl) var1;
             return true;
         }
     }

--- a/STUDIO/org.openl.rules.repository.azure/test/org/openl/rules/repository/azure/AzureYamlMapperFactoryTest.java
+++ b/STUDIO/org.openl.rules.repository.azure/test/org/openl/rules/repository/azure/AzureYamlMapperFactoryTest.java
@@ -18,7 +18,7 @@ class AzureYamlMapperFactoryTest {
 
     @Test
     void testDeserialization() throws IOException {
-        AzureCommit commit = null;
+        AzureCommit commit;
         try (var is = AzureYamlMapperFactoryTest.class.getResourceAsStream("/azureCommitOldStyle.yaml")) {
             commit = mapper.readValue(is, AzureCommit.class);
             assertTheSame(commit);

--- a/STUDIO/org.openl.rules.webstudio.web/pom.xml
+++ b/STUDIO/org.openl.rules.webstudio.web/pom.xml
@@ -43,12 +43,6 @@
             <groupId>org.openl.rules</groupId>
             <artifactId>org.openl.rules.repository.git</artifactId>
         </dependency>
-
-        <!-- For testing purposes -->
-        <dependency>
-            <groupId>org.openl.rules</groupId>
-            <artifactId>org.openl.rules.test</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/STUDIO/org.openl.rules.webstudio.web/test/org/openl/rules/webstudio/web/repository/upload/OpenAPIProjectCreatorTest.java
+++ b/STUDIO/org.openl.rules.webstudio.web/test/org/openl/rules/webstudio/web/repository/upload/OpenAPIProjectCreatorTest.java
@@ -179,7 +179,7 @@ class OpenAPIProjectCreatorTest {
                             engineFactory.getProjectDescriptor(),
                             engineFactory.getRulesInstantiationStrategy());
                 } catch (Exception e) {
-                    error(messagesCount++, startTime, sourceFile, "Compilation fails.", e);
+                    error(messagesCount, startTime, sourceFile, "Compilation fails.", e);
                     testsFailed = true;
                     continue;
                 }

--- a/STUDIO/org.openl.rules.workspace/test/org/openl/rules/workspace/dtr/impl/ProjectIndexSerializerTest.java
+++ b/STUDIO/org.openl.rules.workspace/test/org/openl/rules/workspace/dtr/impl/ProjectIndexSerializerTest.java
@@ -41,7 +41,7 @@ class ProjectIndexSerializerTest {
 
     @Test
     void test() throws IOException {
-        ProjectIndex projectIndex = null;
+        ProjectIndex projectIndex;
         try (var stream = getClass().getResourceAsStream("/openl-projects.yaml")) {
             projectIndex = mapper.readValue(stream, ProjectIndex.class);
             assertTheSame(projectIndex);

--- a/Util/openl-openapi-parser/pom.xml
+++ b/Util/openl-openapi-parser/pom.xml
@@ -38,10 +38,6 @@
         </dependency>
         <dependency>
             <groupId>org.openl.rules</groupId>
-            <artifactId>org.openl.rules.project.openapi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openl.rules</groupId>
             <artifactId>openl-openapi-model-scaffolding</artifactId>
         </dependency>
         <dependency>
@@ -55,16 +51,6 @@
         <dependency>
             <groupId>org.openl.rules</groupId>
             <artifactId>org.openl.rules.ruleservice.ws.common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openl.rules</groupId>
-            <artifactId>org.openl.rules.project</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openl.rules</groupId>
-            <artifactId>openl-excel-builder</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/Util/openl-yaml/test/org/openl/rules/dataformat/yaml/YamlMapperFactoryTest.java
+++ b/Util/openl-yaml/test/org/openl/rules/dataformat/yaml/YamlMapperFactoryTest.java
@@ -45,7 +45,7 @@ class YamlMapperFactoryTest {
     @Test
     void testConfiguration() throws IOException {
         var mapper = YamlMapperFactory.getYamlMapper();
-        MyBean myBean = null;
+        MyBean myBean;
         try (var stream = getClass().getResourceAsStream("/myBean.yaml")) {
             myBean = mapper.readValue(stream, MyBean.class);
             assertTheSame(myBean);

--- a/WSFrontend/org.openl.rules.ruleservice.ws/pom.xml
+++ b/WSFrontend/org.openl.rules.ruleservice.ws/pom.xml
@@ -71,11 +71,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
@@ -85,11 +80,6 @@
         <dependency>
             <groupId>org.openl.rules</groupId>
             <artifactId>org.openl.rules</artifactId>
-        </dependency>
-        <!-- STUDIO -->
-        <dependency>
-            <groupId>org.openl.rules</groupId>
-            <artifactId>org.openl.rules.repository</artifactId>
         </dependency>
         <!-- RulesService -->
         <dependency>

--- a/WSFrontend/org.openl.rules.ruleservice/test/org/openl/rules/ruleservice/OpenLServiceTest.java
+++ b/WSFrontend/org.openl.rules.ruleservice/test/org/openl/rules/ruleservice/OpenLServiceTest.java
@@ -226,7 +226,7 @@ class OpenLServiceTest {
         assertEquals("i: 80 s: Mike", OpenLService.callJSONArgs("RulesFrontendTest_multimodule", "twoArgs", "80", "Mike"));
         assertEquals("i: 80 s: null", OpenLService.callJSONArgs("RulesFrontendTest_multimodule", "twoArgs", "80", null));
 
-        ex = assertThrows(Exception.class, () -> {
+        assertThrows(Exception.class, () -> {
             OpenLService.callJSONArgs("RulesFrontendTest_multimodule", "twoArgs", "Mike", "80");
         });
 


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Daily dead-code sweep. Deletions only — no renames, no refactors. **2 commits, 12 files, 45 deletions / 6 insertions.**
One commit per change type, each spanning every module that change type reaches.

> [!Note]
> **Regrouped and rebased on 2026-07-27.** This PR carried eleven commits of only **two** change types — unused
> dependency declarations and never-read writes — split one commit per file by eleven separate runs of the routine.
> They are now one commit per change type. A later run extended the dependency commit with a fifth pom, so the
> branch has been rebased onto `main` again and the SHAs have changed. Rewriting the SHAs re-runs CI and dismisses
> any existing approval — expected, and the reason for this note. No settled review point is re-opened by it.

## Commit 1 — `Drop dependency declarations unreferenced by their declaring modules`

Five poms, 38 deleted lines: eight declarations of six distinct artifacts. Two artifacts fill two rows each —
`org.openl.rules.project.openapi` and `org.openl.rules.test` are both declared, and unused, in two separate modules.

| Module | Removed | Scope | Evidence |
| --- | --- | --- | --- |
| `Util/openl-openapi-parser` | `org.openl.rules.project.openapi` | compile | The artifact holds exactly two types, `OpenApiGenerator` and `OpenApiGenerationException`; neither name occurs anywhere in the module. |
| `Util/openl-openapi-parser` | `org.openl.rules.project` | test | No `org.openl.rules.project.*` type is imported or named in the module's five test classes. |
| `Util/openl-openapi-parser` | `openl-excel-builder` | test | No `org.openl.rules.excel.builder.*` type, and no `excel`/`ExcelFileBuilder` token, occurs in the module. |
| `STUDIO/org.openl.rules.project.openapi` | `org.openl.rules.test` | test | `RulesInFolderTestRunner`, the artifact's only type, has zero occurrences in the module's `src`, `test` and `test-resources`. |
| `STUDIO/org.openl.rules.webstudio.web` | `org.openl.rules.test` | test | Same artifact, same check: zero occurrences of `RulesInFolderTestRunner` in this module's `src` or `test`. |
| `STUDIO/org.openl.rules.project.validation.openapi` | `org.openl.rules.project.openapi` | compile | Same two types as row 1: zero occurrences in this module's 19 `src` and `test` files, which are its only files — it has no non-Java resources. |
| `WSFrontend/org.openl.rules.ruleservice.ws` | `org.openl.rules.repository` | compile | Zero `openl.rules.repository` / `rules.repository.` tokens across the module's `src`, `test` and `resources`. |
| `WSFrontend/org.openl.rules.ruleservice.ws` | `h2` | test | Zero occurrences of `org.h2.`, `jdbc:`, `DataSource` and `Driver` across the module, which has **no test resources at all**, so no Spring context can configure a datasource. |

Reported by `mvn dependency:analyze-only` under *Unused declared dependencies*. Searched: every `import` in `src` and
`test`, then each artifact's own type names full-text across the whole repository (`grep -rIF`, excluding `target/`
and `node_modules/`).

### Transitive-provider checks

`org.openl.rules.test` is managed by the root pom as **`test` and `optional`** (`pom.xml:1134-1137`). An `optional`
dependency is never propagated to consumers, so **neither of its two removals can change any downstream module's
classpath** — and for the same reason it was never in `Util/openl-openapi-parser`'s closure. Within `webstudio.web`
itself, the one compile-scope artifact it supplied, `org.openl.rules.project`, still arrives through
`org.openl.rules.workspace` (`webstudio.web/pom.xml:28` → `workspace/pom.xml:31`).

Dropping `org.openl.rules.project.openapi` from `openl-openapi-parser` also drops `cxf-rt-frontend-jaxrs` and
`org.openl.rules.jackson` (with `spring-core`) from that module's closure, so both consumers were checked:

- `STUDIO/org.openl.rules.webstudio.web` — still reaches all three through its own
  `org.openl.rules.project.validation.openapi` declaration, which this commit leaves declaring
  `cxf-rt-frontend-jaxrs` and `org.openl.rules.jackson` directly.
- `STUDIO/org.openl.rules.webstudio` — declares `org.openl.rules.project.openapi` **directly** (`pom.xml:250`), so
  its classpath is unchanged. This matters because that module cannot be compiled here (see Verification).

For `STUDIO/org.openl.rules.project.validation.openapi`, `org.openl.rules.project.openapi` supplied **nothing
unique**: its four declarations are `swagger-parser`, `cxf-rt-frontend-jaxrs`, `org.openl.rules.ruleservice.ws.common`
and `org.openl.rules.jackson`, and `validation.openapi` declares all four directly. `mvn dependency:tree` on the
post-change tree confirms it. `org.openl.rules.project`, which that module genuinely uses for `ProjectDescriptor`,
`RulesDeploy`, `RulesInstantiationStrategy`, `ProjectResource` and `ProjectResourceLoader`, did not reach it through
`project.openapi` at all — `project.openapi` does not declare it. Two other compile-scope paths remain:

- `validation.openapi` → `org.openl.rules.jackson` → `org.openl.rules.project` — the path the resolved tree picks.
- `validation.openapi` → `ruleservice.ws.common` → `ruleservice.common` → `org.openl.rules.project`.

Downstream, `OpenApiGenerator` and `OpenApiGenerationException` are reachable from exactly one place in the
repository: `STUDIO/org.openl.rules.webstudio/src/org/openl/rules/webstudio/web/ProjectBean.java:63-64`, and
`webstudio` declares `org.openl.rules.project.openapi` **directly**. The other two consumers of `validation.openapi`
— `STUDIO/org.openl.rules.webstudio.web` and `Util/openl-maven-plugin` — name neither type anywhere, and
`openl-maven-plugin` is build-verified below.

#### `WSFrontend/org.openl.rules.ruleservice.ws` — why removing `org.openl.rules.repository` is safe

This module is a **war**, and OpenL instantiates repository implementations reflectively by fully-qualified class
name from `production-repository.factory`, so stripping the jar out of `WEB-INF/lib` would break at runtime with
nothing failing at compile time. It is not stripped: the module declares **two** other artifacts that themselves
declare `org.openl.rules.repository` at compile scope — `org.openl.rules.ruleservice`
(`ruleservice/pom.xml:57`) and `org.openl.rules.ruleservice.deployer` (`ruleservice.deployer/pom.xml:18`) — so the
jar arrives transitively either way.

Proved rather than argued, two ways:

- **The resolved runtime classpath is byte-identical.** `mvn dependency:list -DincludeScope=runtime` on this module
  before and after the change produces the same **98** entries, `diff`-clean.
- **The built war still packages the jar.** `WEB-INF/lib/org.openl.rules.repository-6.4.0-SNAPSHOT.jar` is present
  in `target/webservice.war` after the removal, among 97 jars.

`h2` is `test` scope, so it is never packaged into the war and never transitive to any consumer.

### Deliberately kept

- `org.apache.cxf:cxf-rt-frontend-jaxrs` in `STUDIO/org.openl.rules.project.validation.openapi` — reported unused
  declared, kept as a **provider**. `Util/openl-maven-plugin` runs `OpenApiProjectValidator`, declares CXF nowhere
  itself, and so reaches CXF only through this pom; `JAXRSOpenLServiceEnhancerHelper` (called at
  `OpenApiProjectValidator:210` and `:251`) applies `org.apache.cxf.jaxrs.ext.multipart.Multipart` and
  `...ext.xml.ElementClass` to the interfaces it generates. `webstudio.web` has no other CXF path either — its
  `jakarta.ws.rs` types come from `ruleservice.ws.common`, whose own CXF declaration is **`provided`** and therefore
  not transitive. This is why one of the two findings in that pom is removed and not both.
- `io.swagger.parser.v3:swagger-parser` — reported unused declared, but it is an **aggregator**:
  `io.swagger.v3.parser.OpenAPIV3Parser` lives in `swagger-parser-v3`, which this artifact is the only path to. The
  same run lists `swagger-parser-v3` and `swagger-parser-core` as *used undeclared*.
- `io.swagger.core.v3:swagger-core-jakarta` — no `io.swagger.v3.core.*` type is used in `openl-openapi-parser`, but
  the root pom **excludes** the non-jakarta `swagger-core` from `swagger-parser` (`pom.xml:909`), making this
  declaration the deliberate jakarta substitute `swagger-parser-v3` needs at runtime.
- The two remaining `cxf-rt-*` findings and `log4j-slf4j2-impl` in `WSFrontend/org.openl.rules.ruleservice.ws`.
  `log4j-slf4j2-impl` is `runtime` scope and `Log4jRoutingTest` exists specifically to pin that bridge wiring.
- The inherited findings every module reports (`jspecify`, `lombok`, `junit-jupiter`, `junit-pioneer`,
  `mockito-junit-jupiter`, `log4j-to-slf4j`) are annotation processors or test runtime.

## Commit 2 — `Remove never-read writes across DEV, STUDIO, Util and WSFrontend`

Seven files, 7 deleted and 6 inserted lines. A never-read write is a value written and then overwritten or discarded
before any read. Six of the seven rewrite the line rather than only deleting it — four drop a `= null` from a
declaration, one drops a `++` from a call argument, one drops a store from an expression statement; the seventh
deletes a whole statement. Reported by PMD `UnusedAssignment` and `UnusedLocalVariable`. For locals, javac enforces
definite assignment, so an unsound removal fails to **compile** rather than failing silently.

| File | Change | Why the write is dead |
| --- | --- | --- |
| `DEV/org.openl.rules.project/.../ProjectDescriptor.java:148` | `String suffix = null;` → `String suffix;` | Both branches of the following `if`/`else` assign it before its single read at line 161. |
| `STUDIO/org.openl.rules.repository.azure/test/.../AzureYamlMapperFactoryTest.java:21` | `AzureCommit commit = null;` → `AzureCommit commit;` | Assigned as the first statement of a try-with-resources with **no catch clause**, so definitely assigned at the read on line 26. |
| `STUDIO/org.openl.rules.workspace/test/.../ProjectIndexSerializerTest.java:44` | `ProjectIndex projectIndex = null;` → `ProjectIndex projectIndex;` | Same shape; definitely assigned at the read on line 49, and the method declares `throws IOException` so a `readValue` failure propagates instead of reaching it. |
| `Util/openl-yaml/test/.../YamlMapperFactoryTest.java:48` | `MyBean myBean = null;` → `MyBean myBean;` | Same shape; assigned first inside a catch-less try-with-resources, read at `assertNotNull` after the block. |
| `WSFrontend/org.openl.rules.ruleservice/test/.../OpenLServiceTest.java:229` | `ex = assertThrows(...)` → `assertThrows(...)` | `ex` is reassigned at line 249 before its next read at 252. `ex` is still used, so the declaration stays and no unused local is left. |
| `STUDIO/org.openl.rules.project.validation.openapi/test/.../ServiceExtraMethodHandlerImpl.java:34` | drops `ServiceExtraMethodHandlerImpl var2 = (ServiceExtraMethodHandlerImpl) var1;` | `var2` was never read, and the `this.getClass() != var1.getClass()` guard on the line above makes the cast unable to throw, so `equals` cannot change. |
| `STUDIO/org.openl.rules.webstudio.web/test/.../OpenAPIProjectCreatorTest.java:182` | `error(messagesCount++, ...)` → `error(messagesCount, ...)` | `messagesCount` is declared **inside** the `for (File file : files)` loop (line 143) and the `continue` two lines below ends the iteration, so the increment is discarded before the counter's only read at line 271. Both forms pass the pre-value `0`. |

Two files are of the `YamlMapperFactoryTest` family, which this sweep's notes flag as a false-positive risk. That
warning concerns **reflective accessors on the nested test beans** (`MyBean`), which are read by the code under test.
This commit changes only local variable initializers; the beans and their accessors are untouched.

`OpenLServiceTest:229` loses only the **store**, not the assertion: `assertThrows` still runs and still fails the
test if nothing is thrown. That assertion was already the weakest of its five neighbours — the captured `ex` was
never asserted on, which is exactly what made the store dead — so its strength is unchanged. It fires on
`com.fasterxml.jackson.core.JsonParseException` ("Unrecognized token 'Mike'"), verified by probe, which is why the
broad `Exception.class` is load-bearing and cannot simply be narrowed to match its neighbours.

## Verification

- Whole reactor on the current tree:
  `mvn clean install -Dquick -DnoPerf -T1C -pl '!STUDIO/org.openl.rules.webstudio,!STUDIO/studio-ui'` —
  **47 SUCCESS, zero test failures anywhere.** The only failures are `itest.studio.acl`,
  `itest.studio.disabled-settings` and `itest.studio.dtr`, all three at dependency resolution on
  `org.openl.rules.webstudio:war`, the deliberately excluded module; the remaining skips cascade from them.
  Every module this PR touches is in the SUCCESS set, including `OpenL - Ruleservice - Web Services`, with the
  tests over the changed files green: `YamlMapperFactoryTest`, `AzureYamlMapperFactoryTest`,
  `ProjectIndexSerializerTest`, `OpenLServiceTest`, `OpenApiProjectValidatorTest` and `OpenAPIProjectCreatorTest`.
- The two modules the reactor halt left unbuilt were then built explicitly, both **BUILD SUCCESS**:
  `-pl DEV/org.openl.rules.test,WSFrontend/org.openl.rules.ruleservice.ws,WSFrontend/org.openl.rules.ruleservice.ws.all`
  and `-pl Util/openl-maven-plugin`. `openl-maven-plugin` is named on purpose — it is the consumer that reaches
  `org.openl.rules.ruleservice.ws` and CXF only through the edited poms, and a reactor halt would otherwise have
  shipped it unverified.
- `mvn dependency:list -DincludeScope=runtime` on `ruleservice.ws` before and after: **98 entries, `diff`-clean.**
  The built `webservice.war` still contains `WEB-INF/lib/org.openl.rules.repository-6.4.0-SNAPSHOT.jar`.
- `mvn -o dependency:tree` and `mvn -o dependency:analyze` re-run on the changed modules: no artifact became newly
  unused, and no artifact the changed modules compile against lost its last path.
- `mvn validate -N` clean, no Spotless churn.

`DEV/org.openl.rules.test` must be inside the reactor to build any module that depends on it. The root pom ties
`maven.install.skip` to `maven.deploy.skip` (`pom.xml:79`), and that module sets `maven.deploy.skip` to `true`, so
its artifact is **never installed** and a bare `-pl` on a consumer cannot resolve it. That resolution failure
reproduces identically at the pre-change commit, so it is environmental.

`STUDIO/org.openl.rules.webstudio` cannot be compiled in the sweep container: the root pom's
`org.opensaml:opensaml-bom` is published only on `build.shibboleth.net`, which the sandbox egress policy refuses with
HTTP 403. That module is excluded from the local reactor, so GitHub Actions is the authoritative gate for it — the
reachability arguments above are why these changes cannot affect it.

## Known follow-ups, agreed as a separate hygiene PR

All five are *additions* or *strengthenings*, which this deletion-only sweep does not do. Every one pre-dates this
PR and nothing is broken today — each artifact still resolves transitively.

1. Declare `commons-lang3` (compile) and `groovy` (test) in `Util/openl-openapi-parser` — both *used undeclared*.
   `commons-lang3` has two paths (`swagger-core-jakarta`, nearest, and `DEV/org.openl.rules/pom.xml:26`); only
   `groovy` depends on a single path.
2. Declare `commons-lang3` in `STUDIO/org.openl.rules.project.openapi` — `OpenAPIGenerationTest:23` imports
   `org.apache.commons.lang3.tuple.Pair` and reaches it only transitively.
3. Declare `commons-lang3` in `STUDIO/org.openl.rules.project.validation.openapi` — and this one is **production**
   code, not test: `OpenApiProjectValidator.java:58` imports `org.apache.commons.lang3.tuple.Pair`, and lines
   1249-1300 call `org.apache.commons.lang3.StringUtils` fully qualified.
4. Declare `org.openl.rules.project` in `STUDIO/org.openl.rules.project.validation.openapi` — the module uses
   `ProjectDescriptor`, `RulesDeploy`, `RulesInstantiationStrategy`, `RulesInstantiationException`, `ProjectResource`
   and `ProjectResourceLoader`, reaching them only through `org.openl.rules.jackson` and `ruleservice.ws.common`.
   Pre-existing, and not introduced here — `project.openapi` did not declare it either, which is exactly why the
   reachability argument above holds.
5. Strengthen `OpenLServiceTest:229` to `assertThrows(JsonParseException.class, …)` plus the message assertion.

## Also scanned, nothing found

- `Util/openl-maven-plugin` — all six of its *unused declared* findings are **false positives by construction, and
  none was removed.** The plugin reads its own dependency list at runtime **by Maven coordinate string**:
  `VerifyMojo.getJars(String)` filters `${plugin.artifacts}` and ends in `.findFirst().get()`, so a removed
  declaration becomes a `NoSuchElementException` at goal execution with nothing failing at compile time.
  `org.openl.rules.ruleservice.ws` (`VerifyMojo:74`), `jetty-ee10-annotations` (`:95`) and `log4j-to-slf4j` (`:89`)
  are named exactly that way; the rest feed the runtime classpath the mojo hands to the booted rule-service app.
  Its dependency block is a runtime classpath manifest, not a compile classpath.
- `STUDIO/org.openl.security.standalone` — its six Spring/Hibernate/Hikari findings are runtime false positives.
  `resources/META-INF/standalone/spring/security-hibernate-beans.xml` instantiates
  `com.zaxxer.hikari.HikariDataSource`, `org.springframework.orm.hibernate5.LocalSessionFactoryBean` /
  `HibernateTransactionManager` and `org.springframework.integration.jdbc.lock.JdbcLockRegistry` /
  `DefaultLockRepository` by `class=` string. Bytecode analysis cannot see those.
- `STUDIO/studio-ui` — `npx tsc --noEmit` clean, `npx eslint ./src` clean, and all 543 top-level exports have at
  least one reference.
- `WSFrontend/org.openl.rules.ruleservice.ws/resources/static/rapi-doc/` (1.3 MB of vendored JavaScript) — **live**,
  loaded by `resources/static/swagger-ui.html` in the same module. Not removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)