### PR TITLE
Pin Micrometer to 1.15.12 to fix denial-of-service vulnerability CVE-2026-40984

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1569,7 +1569,6 @@
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>3.9.0</version>
                 <inherited>false</inherited>
-                
                 <configuration>
                     <upToDateChecking>
                         <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -1569,6 +1569,7 @@
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>3.9.0</version>
                 <inherited>false</inherited>
+                
                 <configuration>
                     <upToDateChecking>
                         <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,9 @@
         <spring.boot.version>3.5.16</spring.boot.version>
         <spring.integration.version>6.5.10</spring.integration.version>
         <!-- Newer than Spring Boot 3.5.16 manages by default, fixing CVE-2026-40984 (GHSA-g3pr-3p32-fp23),
-             a denial-of-service vulnerability in Micrometer's HTTP server instrumentation.
-             Remove once Spring Boot ships this version by default. -->
+             a denial-of-service vulnerability in Micrometer's HTTP server instrumentation. micrometer-core
+             is a required (compile-scope) dependency of spring-ldap-core, not an optional add-on.
+             Remove once spring-ldap-core 4.x (requires Spring Framework 7.x) manages a fixed version by default. -->
         <micrometer.version>1.15.12</micrometer.version>
 
         <!-- Security -->
@@ -462,8 +463,9 @@
                 <version>${spring.boot.version}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Override the micrometer-core (and micrometer-jetty11/micrometer-jetty12) that Spring Boot drags
-                 in with a newer release. Remove once Spring Boot ships this version by default. -->
+            <!-- Override the micrometer-core that spring-ldap-core requires as a compile-scope dependency,
+                 with a newer release fixing CVE-2026-40984. Remove once spring-ldap-core 4.x (requires
+                 Spring Framework 7.x) manages a fixed version by default. -->
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,10 @@
         <spring.framework.version>6.2.19</spring.framework.version>
         <spring.boot.version>3.5.16</spring.boot.version>
         <spring.integration.version>6.5.10</spring.integration.version>
+        <!-- Newer than Spring Boot 3.5.16 manages by default, fixing CVE-2026-40984 (GHSA-g3pr-3p32-fp23),
+             a denial-of-service vulnerability in Micrometer's HTTP server instrumentation.
+             Remove once Spring Boot ships this version by default. -->
+        <micrometer.version>1.15.12</micrometer.version>
 
         <!-- Security -->
         <spring.security.version>6.5.11</spring.security.version>
@@ -457,6 +461,15 @@
                 <artifactId>spring-boot-starter-test</artifactId>
                 <version>${spring.boot.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <!-- Override the micrometer-core (and micrometer-jetty11/micrometer-jetty12) that Spring Boot drags
+                 in with a newer release. Remove once Spring Boot ships this version by default. -->
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-bom</artifactId>
+                <version>${micrometer.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- Spring Security -->
             <dependency>


### PR DESCRIPTION
Vulnerability in dependency:
io.micrometer:micrometer-core | CVE-2026-40984
	
https://github.com/advisories/GHSA-g3pr-3p32-fp23