### PR TITLE
Resolve Spotless line endings on a per-file basis for windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1573,6 +1573,12 @@
                     <upToDateChecking>
                         <enabled>true</enabled>
                     </upToDateChecking>
+                    <!-- Resolve the line ending per file. The plugin default, GIT_ATTRIBUTES_FAST_ALLSAME,
+                         resolves only the first file of a format and reuses that answer for the rest. Formats
+                         here span both '* text=auto' paths and paths pinned to 'eol=lf' by .gitattributes, so
+                         that shortcut rewrites the whole format to one ending. On Windows, where 'text=auto'
+                         checks out as CRLF, it turned every such file into a spurious modification. -->
+                    <lineEndings>GIT_ATTRIBUTES</lineEndings>
                     <java>
                         <includes>
                             <include>**/*.java</include>
@@ -1666,7 +1672,6 @@
                     </pom>
                     <formats>
                         <format>
-                            <lineEndings>GIT_ATTRIBUTES</lineEndings>
                             <includes>
                                 <include>**/*.ts</include>
                                 <include>**/*.tsx</include>


### PR DESCRIPTION
This change fixes line endings while build on Windows:
```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:3.9.0:check (spotless-check) on project openl-tablets: The following files had format violations:
[ERROR]     ITEST\itest.smoke\openl-repository\deployments\no-xlsx\common\groovy\util\Util.groovy
[ERROR]         @@ -1,7 +1,7 @@
[ERROR]         -package util\r\n
[ERROR]         -\r\n
[ERROR]         -class Util {\r\n
[ERROR]         -    static String ping() {\r\n
[ERROR]         -        "pong!"\r\n
[ERROR]         -    }\r\n
[ERROR]         -}\r\n
[ERROR]         +package util\n
[ERROR]         +\n
[ERROR]         +class Util {\n
[ERROR]         +    static String ping() {\n
[ERROR]         +        "pong!"\n
[ERROR]         +    }\n
[ERROR]         +}\n
```