### PR TITLE
EPBDS-16436 Match the published migration page URL so the Migration Notes block renders

### DIFF
--- a/Docs/_layouts/release-notes.html
+++ b/Docs/_layouts/release-notes.html
@@ -2,14 +2,26 @@
 layout: single
 ---
 
-{%- assign migration_url = page.url | append: "migration/" -%}
+{%- comment -%}
+  Locate <version>/migration.md among site.pages. Match on the source path, which does not depend on
+  the permalink style: this site sets `permalink: /:categories/:title`, so Jekyll adds no suffix to page
+  URLs and the migration page is served at .../migration (no extension, no trailing slash). The URL
+  comparison is kept as a second, equivalent check. `release-notes` pages, including migration.md itself,
+  all use this same layout, so skip the lookup on the migration page to avoid it embedding its own content.
+{%- endcomment -%}
+{%- assign migration_path = page.dir | append: "migration.md" -%}
+{%- assign migration_url = page.url | append: "migration" -%}
+{%- assign current_path = page.path | prepend: "/" -%}
 {%- assign migration_page = nil -%}
-{%- for p in site.pages -%}
-  {%- if p.url == migration_url -%}
-    {%- assign migration_page = p -%}
-    {%- break -%}
-  {%- endif -%}
-{%- endfor -%}
+{%- if current_path != migration_path -%}
+  {%- for p in site.pages -%}
+    {%- assign p_path = p.path | prepend: "/" -%}
+    {%- if p_path == migration_path or p.url == migration_url -%}
+      {%- assign migration_page = p -%}
+      {%- break -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif -%}
 
 {%- assign sections = content | split: '<h2 ' -%}
 {%- assign toc_count = sections.size | minus: 1 -%}


### PR DESCRIPTION
## Summary
- The release-notes layout looked up each version's `migration.md` by comparing against `page.url` variants (`.../migration.html`, `.../migration/`), but this site's `permalink: /:categories/:title` style serves the page at `.../migration` with no suffix, so the lookup never matched and the Migration Notes block never rendered for any of the 48 release-notes versions that have a migration.md.
- Match on the source path instead (`page.dir` + `migration.md` compared against `page.path`), which does not depend on the permalink style. The URL comparison is kept as a second, equivalent check.
- Fixed a follow-on duplication: since `_config.yml` applies the `release-notes` layout to every page under that path — including `migration.md` itself — the same lookup on the migration page found itself, appending its own content a second time. The layout now skips the lookup when the current page is itself the migration page.

Affects all 48 release-notes versions that have a migration.md.

Jira: https://jira.eisgroup.com/browse/EPBDS-16436

## Test plan
- [x] Published the branch to GitHub Pages and visually confirmed the Migration Notes block renders on release-notes index pages
- [x] Confirmed `release-notes/6.3.0/migration.html` shows its content once, no duplication