### PR TITLE
Remove dead code in legacy WebStudio CSS

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/webapp/css/common.css
+++ b/STUDIO/org.openl.rules.webstudio/webapp/css/common.css
@@ -424,17 +424,6 @@ fieldset {
     color: rgb(71,71,71);
 }
 
-.titleColumn, .fields section div .titleColumn {
-    width: 150px;
-    padding-right: 5px;
-    padding-top: 8px;
-    padding-bottom: 5px;
-}
-
-.titleColumn:empty, .fields section div .titleColumn:empty {
-    padding: 0px;
-}
-
 .block-column {
     display: inline-block;
     vertical-align: top;


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Deletion-only sweep. 1 commit, 1 file changed, 11 deletions.

## Drop the common.css titleColumn rules orphaned by the retired commit info dialog

**What was removed** — the two rule blocks in `STUDIO/org.openl.rules.webstudio/webapp/css/common.css` whose
selectors name the `titleColumn` class: the sizing block and its `:empty` companion.

**Evidence** — `titleColumn` was applied by exactly one page, `webapp/pages/modules/configureCommitInfo.xhtml`,
which commit 957c5ca (EPBDS-16422, Open the editor Save and Export dialogs in React) deleted. A repo-wide plain
full-text search now finds the token in `common.css` alone:

```
grep -rIF titleColumn . --exclude-dir=target --exclude-dir=node_modules
```

The class is not composed at runtime — unlike `ui-layout-*`, `tooltip_*` and `te_toolbar_*`, no JavaScript or Java
in the repository builds it by concatenation, and it is not a RichFaces (`rf-`) or antd (`ant-`) name that ships
inside a jar or a bundle. The scan behind this was a full extraction of every class and id selector from all six
CSS files under `webapp/css`, each resolved repo-wide; `titleColumn` was the only orphan among 132 classes in
`common.css` and the only one across the whole folder.

**Verification** — `common.css` is loaded verbatim by `pages/modules/index.xhtml` and `pages/layout/simpleLayout.xhtml`;
there is no build step or minified bundle to regenerate for it, so the removal reaches the runtime as written.
`mvn validate -N` passes with no formatting churn. Nothing compiles against a stylesheet, so the GitHub Actions
build on this pull request is the remaining gate.

**Deliberately kept**

- `.fields`, `.fields section`, `.fields section > h3` and `.fields section > div` — still applied by surviving
  pages, so only the `titleColumn` selectors went and the surrounding family stays.
- `rf-*` and `ant-select-input` in `common.css`, and every `ui-layout-*` rule in `css/layout/main.css` — RichFaces
  ships its JavaScript inside a jar, antd applies its classes at runtime, and the layout names are built by string
  concatenation. None can be proven dead from this repository.
- `font-size-80pct` and `font-weight-bold`, both used by the same deleted page, are defined in no stylesheet at
  all, so nothing was left to delete.

**Deferred** — `common.js:127` guards a submit handler with `!$submit.hasClass('own-loader-handler')`. That class
was carried only by the Export buttons of the two deleted JSF dialogs, so the guard can no longer be false, but
removing it rewrites a live condition rather than deleting a dead declaration. Left for a human, together with the
comment above it that documents the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uxh4YPs9v5oe8HCH9UFbSn)_