### PR TITLE
Remove dead code in Maven dependency metadata

### DIFF
--- a/ITEST/pom.xml
+++ b/ITEST/pom.xml
@@ -74,12 +74,6 @@
                 <groupId>org.openl.rules</groupId>
                 <artifactId>org.openl.rules.webstudio</artifactId>
                 <version>${project.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.openl.rules</groupId>
-                <artifactId>org.openl.rules.webstudio</artifactId>
-                <version>${project.version}</version>
                 <type>war</type>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1122,11 +1122,6 @@
             </dependency>
             <dependency>
                 <groupId>org.openl.rules</groupId>
-                <artifactId>org.openl.rules.webstudio</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.openl.rules</groupId>
                 <artifactId>org.openl.rules.workspace</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Automated dead-code sweep. One commit per change type; every removal is proved unreferenced before it ships.

Totals on this head: 1 commit, 2 files, 11 deleted lines (`git diff --shortstat main..HEAD`).

## Drop the managed webstudio jar entries no module can consume

**What was removed.** The two `dependencyManagement` entries for `org.openl.rules:org.openl.rules.webstudio`
that carry no `type`, and therefore manage the default jar artifact — one in the root `pom.xml`, one in
`ITEST/pom.xml`. The `war`-typed entries beside them are untouched and stay.

**Evidence.**

- Every `dependency` and `artifactItem` block in all 208 poms was parsed and keyed by group, artifact, type and
  classifier. Every declaration of `org.openl.rules.webstudio` anywhere in the repository is `war`-typed:
  nine ITEST suites, `jacoco-report`, and the root entry that manages them. Not one declares the jar.
- No transitive node can reach it either, because the module produces no jar: `STUDIO/org.openl.rules.webstudio`
  is `war`-packaged, and neither its own pom nor the root war-plugin configuration attaches a classes jar.
- A managed entry with no declaration and no reachable transitive node is dead — the same rule under which the
  earlier sweeps removed managed entries and exclusions.

**Verification.** `mvn help:effective-pom -Pitest` over the whole reactor before and after the edit, 172
effective POMs each time. The diff adds **0** lines and removes 451 — exactly the one jar entry from each of the
84 effective POMs that inherited it, and nothing else. No `type` line and no `war` entry appears in the diff.
`mvn validate -N` passes and leaves no formatting churn.

**Deliberately kept.**

- Both `war`-typed webstudio entries, and both `org.openl.rules.ruleservice.ws` entries: the jar variant of that
  artifact **is** declared, by four modules.
- The duplicated-looking pairs in `ITEST/pom.xml` are not duplicates — each pair differs by `type`.
- `Docs/examples/production` and `Docs/production-deployment` example poms, and the `openl-maven-plugin` `it/`
  fixture poms, are out of scope.

## Swept this run with no finding

- Pom `resource` and `testResource` directories against the tree: every declared directory in a production
  module exists.
- CSS animation names and custom properties: the repository declares none of either.
- Selector deadness in `DEMO/webapps/ROOT/main.css`, the one own stylesheet earlier sweeps had not covered:
  every id and class is used by `index.html`.
- Public and protected members of package-private top-level classes — 246 types, 121 non-overriding members.
  Every one has a caller.
- Public and protected members of non-public nested classes — 318 types, 65 non-overriding members. Every one
  has a caller; the single name-unique hit is a Jackson MixIn method, which is unreferenced by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSfS813B6v8fWtBW4Q2c5Q)_