### PR TITLE
Remove dead code in Java sources, scripts and stylesheets

### DIFF
--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/Constrainer.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/Constrainer.java
@@ -202,12 +202,9 @@ public final class Constrainer implements Serializable {
         _backtrack_objects = new FastVector();
         _trace_goals = false;
 
-        // _failure = new Failure();
         _trace_failure_stack = false;
 
         _print_information = false;
-
-        // _undo_subject_factory = new UndoSubjectFactory();
 
         _expressionFactory = new ExpressionFactoryImpl(this);
 
@@ -222,7 +219,6 @@ public final class Constrainer implements Serializable {
     IntBoolVar addIntBoolVar(IntBoolVar var) {
         _intvars.add(var);
         addUndo(UndoFastVectorAdd.getUndo(_intvars));
-        // addObjectToSymbolicContext(var.name(),var);
         return var;
     }
 
@@ -295,7 +291,6 @@ public final class Constrainer implements Serializable {
     IntVar addIntVar(IntVar var) {
         _intvars.addElement(var);
         addUndo(UndoFastVectorAdd.getUndo(_intvars));
-        // addObjectToSymbolicContext(var.name(),var);
         return var;
     }
 
@@ -305,7 +300,6 @@ public final class Constrainer implements Serializable {
     IntVar addIntVarInternal(IntVar var) {
         _intvars.addElement(var);
         addUndo(UndoFastVectorAdd.getUndo(_intvars));
-        // addInternalObjectToSymbolicContext(var);
         return var;
     }
 
@@ -344,7 +338,6 @@ public final class Constrainer implements Serializable {
      */
     public void addUndo(Undo undo_object) {
         _number_of_undos++;
-        // Debug.on();Debug.print("add " + undo_object);Debug.off();
         _reversibility_stack.pushUndo(undo_object);
     }
 
@@ -421,7 +414,6 @@ public final class Constrainer implements Serializable {
         while (!_propagation_queue.isEmpty()) {
             var var = (Subject) _propagation_queue.remove();
             var.inProcess(false);
-            // var.clearPropagationEvents();
         }
     }
 
@@ -572,9 +564,6 @@ public final class Constrainer implements Serializable {
             }
         }
 
-        /*
-         * if (showInternalNames()) _failure.message(s); else _failure.message("");
-         */
         throw new Failure(s);// _failure; //
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/ConstrainerObjectImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/ConstrainerObjectImpl.java
@@ -77,16 +77,7 @@ public class ConstrainerObjectImpl implements ConstrainerObject {
      * Sets name and manages symbolic context for this object.
      */
     protected void symbolicName(String name) {
-        // String oldName = _name;
         _name = name;
-        // try
-        // {
-        // constrainer().symbolicContext().renameVar(oldName,name,this);
-        // }
-        // catch(Exception e)
-        // {
-        // constrainer().out().println(e.getMessage());
-        // }
     }
 
     /**

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/Domain.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/Domain.java
@@ -16,7 +16,6 @@ import java.io.Serializable;
  * the program(s) have been supplied.
  */
 ///////////////////////////////////////////////////////////////////////////////
-//import java.util.Set;
 
 /**
  * An interface for the domain of the constrained integer variable. Domain is a set of the possible values of the
@@ -119,7 +118,5 @@ public interface Domain extends Serializable {
      * Sets the variable associated with this domain.
      */
     void variable(IntVar var);
-
-    // public Set set();
 
 } // ~Domain

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalAnd.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalAnd.java
@@ -52,7 +52,6 @@ public class GoalAnd extends GoalImpl {
      */
     @Override
     public Goal execute() throws Failure {
-        // Debug.print("Execute "+this);
         constrainer().pushOnExecutionStack(_g2);
         constrainer().pushOnExecutionStack(_g1);
         return null;

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalGenerate.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalGenerate.java
@@ -52,7 +52,6 @@ public class GoalGenerate extends GoalImpl {
      */
     @Override
     public Goal execute() throws Failure {
-        // Debug.on();Debug.print("Generate"+_intvars);Debug.off();
         var index = -1;
         var size = _intvars.size();
         for (var i = 0; i < size; i++) {
@@ -65,9 +64,6 @@ public class GoalGenerate extends GoalImpl {
         if (index == -1) {
             return null; // all vars are instantiated
         }
-
-        // IntVar var = (IntVar)_intvars.elementAt(index);
-        // Debug.on();Debug.print("Var Selected:"+var);Debug.off();
 
         var search_goal = (Goal) _goals.elementAt(index);
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalImpl.java
@@ -35,7 +35,6 @@ public abstract class GoalImpl extends ConstrainerObjectImpl implements Goal {
 
     public GoalImpl(Constrainer c, String name) {
         super(c, name);
-        // c.addGoal(this);
     }
 
 } // ~GoalImpl

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalInstantiate.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalInstantiate.java
@@ -76,7 +76,6 @@ public class GoalInstantiate extends GoalImpl {
                     goal_limit = _goal_max;
                 }
             }
-            // Debug.on();Debug.print(this + " by "+chosen_value);Debug.off();
 
             return new GoalOr(_goal_value, new GoalAnd(goal_limit, GoalInstantiate.this));
         }

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalOr.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalOr.java
@@ -38,7 +38,6 @@ public class GoalOr extends GoalImpl {
      */
     @Override
     public Goal execute() throws Failure {
-        // Debug.print("Execute "+this);
         constrainer().setChoicePoint(_g1, _g2, _label);
         return null;
     }

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalRemoveValue.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalRemoveValue.java
@@ -22,8 +22,6 @@ public class GoalRemoveValue extends GoalImpl {
     private final IntExp _exp;
     private int _value;
 
-    // private UndoableInt _valueI;
-
     public GoalRemoveValue(IntExp exp) {
         this(exp, exp.max() + 1); // value has to be set later
     }
@@ -32,21 +30,17 @@ public class GoalRemoveValue extends GoalImpl {
         super(exp.constrainer(), "remove");
         _exp = exp;
         _value = value;
-        // _valueI = _constrainer.addUndoableInt(value,"remove");
     }
 
     @Override
     public Goal execute() throws Failure {
-        // Debug.print("\nExecute "+this);
         _exp.removeValue(_value);
-        // _exp.removeValue(_valueI.value());
         return null;
     }
 
     @Override
     public String toString() {
         return _exp + "!=" + _value;
-        // return _exp+"!="+_valueI.value();
     }
 
     /**
@@ -54,7 +48,6 @@ public class GoalRemoveValue extends GoalImpl {
      */
     public void value(int v) {
         _value = v;
-        // _valueI.setValue(v);
     }
 
 } // ~GoalRemoveValue

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalSetMax.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalSetMax.java
@@ -22,8 +22,6 @@ public class GoalSetMax extends GoalImpl {
     private final IntExp _exp;
     private int _max;
 
-    // private UndoableInt _maxI;
-
     /**
      * Invokes <code>GoalSetMax(exp,exp.max())</code>
      *
@@ -33,7 +31,6 @@ public class GoalSetMax extends GoalImpl {
         super(exp.constrainer(), "max");
         _exp = exp;
         _max = exp.max();
-        // _maxI = _constrainer.addUndoableInt(max,"max");
     }
 
     /**
@@ -43,9 +40,7 @@ public class GoalSetMax extends GoalImpl {
      */
     @Override
     public Goal execute() throws Failure {
-        // Debug.print("\nExecute "+this);
         _exp.setMax(_max);
-        // _exp.setMax(_maxI.value());
         return null;
     }
 
@@ -54,12 +49,10 @@ public class GoalSetMax extends GoalImpl {
      */
     public void max(int M) {
         _max = M;
-        // _maxI.setValue(M);
     }
 
     @Override
     public String toString() {
         return _exp + "<=" + _max;
-        // return _exp+"<="+_maxI.value();
     }
 }

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalSetMin.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalSetMin.java
@@ -22,20 +22,15 @@ public class GoalSetMin extends GoalImpl {
     private final IntExp _exp;
     private int _min;
 
-    // private UndoableInt _minI;
-
     public GoalSetMin(IntExp exp) {
         super(exp.constrainer(), "min");
         _exp = exp;
         _min = exp.min();
-        // _minI = _constrainer.addUndoableInt(min,"min");
     }
 
     @Override
     public Goal execute() throws Failure {
-        // Debug.print("\nExecute "+this);
         _exp.setMin(_min);
-        // _exp.setMin(_minI.value());
         return null;
     }
 
@@ -44,13 +39,11 @@ public class GoalSetMin extends GoalImpl {
      */
     public void min(int m) {
         _min = m;
-        // _minI.setValue(m);
     }
 
     @Override
     public String toString() {
         return _exp + ">=" + _min;
-        // return _exp+">="+_minI.value();
     }
 
 }

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalSetValue.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/GoalSetValue.java
@@ -32,8 +32,6 @@ public class GoalSetValue extends GoalImpl {
         this(exp, exp.min() - 1); // value has to be set later
     }
 
-    // private UndoableInt _valueI;
-
     /**
      * Creates the goal that is ready to make an IntExp type variable bound by setting it up.
      *
@@ -44,7 +42,6 @@ public class GoalSetValue extends GoalImpl {
         super(exp.constrainer(), "set");
         _exp = exp;
         _value = value;
-        // _valueI = _constrainer.addUndoableInt(value,"set");
     }
 
     /**
@@ -56,16 +53,13 @@ public class GoalSetValue extends GoalImpl {
      */
     @Override
     public Goal execute() throws Failure {
-        // Debug.print("\nExecute "+this);
         _exp.setValue(_value);
-        // _exp.setValue(_valueI.value());
         return null;
     }
 
     @Override
     public String toString() {
         return _exp + "=" + _value;
-        // return _exp+"="+_valueI.value();
     }
 
     /**
@@ -75,7 +69,6 @@ public class GoalSetValue extends GoalImpl {
      */
     public void value(int v) {
         _value = v;
-        // _valueI.setValue(v);
     }
 
 } // ~GoalSetValue

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/IntBoolExpConst.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/IntBoolExpConst.java
@@ -24,7 +24,6 @@ public class IntBoolExpConst extends IntExpConst implements IntBoolExp {
      * Acts like a following constructor: <code>new IntBoolExpConst(c,value)</code>
      */
     public static IntBoolExpConst getIntBoolExpConst(Constrainer c, boolean value) {
-        // return new IntBoolExpConst(constrainer(),value);
         return (IntBoolExpConst) c.expressionFactory()
                 .getExpression(IntBoolExpConst.class,
                         new Object[]{c, value},

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/IntExpArray.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/IntExpArray.java
@@ -318,13 +318,11 @@ public final class IntExpArray extends ConstrainerObjectImpl {
     public IntExp sum() {
         return switch (size()) {
             case 0 ->
-                // return new IntExpConst(constrainer(),0);
                 (IntExp) _constrainer.expressionFactory()
                         .getExpression(IntExpConst.class, new Object[]{_constrainer, 0});
             case 1 -> _data[0];
             case 2 -> _data[0].add(_data[1]);
             default ->
-                // return new IntExpAddArray(_constrainer, this);
                 (IntExp) _constrainer.expressionFactory()
                         .getExpression(
                                 // IntExpAddArray.class,

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/IntExpConst.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/IntExpConst.java
@@ -27,7 +27,6 @@ public class IntExpConst extends IntExpImpl {
      */
     @Override
     final public IntExp add(int value) {
-        // return new IntExpConst(constrainer(),_const + value);
         return getIntExp(IntExpConst.class, _const + value);
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/UndoImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/UndoImpl.java
@@ -22,7 +22,6 @@ import org.openl.ie.tools.ReusableImpl;
  */
 
 public class UndoImpl extends ReusableImpl implements Undo {
-    // private boolean _undone_flag;
     protected Undoable _undoable;
 
     /**

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/consistencyChecking/OverlappingCheckerImpl2.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/consistencyChecking/OverlappingCheckerImpl2.java
@@ -118,15 +118,12 @@ public class OverlappingCheckerImpl2 implements OverlappingChecker {
                     int B = _dt.isOverrideAscending() ? j : i;
 
                     if (completelyOverlaps(_dt.getRule(rules[A]), _dt.getRule(rules[B]))) {
-                        // System.out.println(" +***+ Checking " + rules[A] + " vs " + rules[B] + " = blocks");
                         this.overlappings
                                 .add(new Overlapping(ovl, rules[A], rules[B], Overlapping.OverlappingStatus.BLOCK));
                     } else if (completelyOverlaps(_dt.getRule(rules[B]), _dt.getRule(rules[A]))) {
-                        // System.out.println(" +***+ Checking " + rules[A] + " vs " + rules[B] + " = overrides");
                         this.overlappings
                                 .add(new Overlapping(ovl, rules[A], rules[B], Overlapping.OverlappingStatus.OVERRIDE));
                     } else /* if (!blocks && !overrides) */ {
-                        // System.out.println(" +***+ Checking " + rules[A] + " vs " + rules[B] + " = partial overlap");
                         this.overlappings
                                 .add(new Overlapping(ovl, rules[A], rules[B], Overlapping.OverlappingStatus.PARTIAL));
                     }
@@ -154,12 +151,10 @@ public class OverlappingCheckerImpl2 implements OverlappingChecker {
         var C = exp1.constrainer();
         var stackSize = C.getStackSize();
         var overlaps = exp1.lt(exp2).asConstraint();
-        // GoalCompare compare = new GoalCompare(C, exp1, exp2);
         var generate = new GoalGenerate(_dt.getVars());
         var target = new GoalAnd(overlaps, generate);
         var flag = C.execute(target, true);
         C.backtrackStack(stackSize);
-        // boolean res = compare.result;
         return !flag;
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ConstraintExpEqualsValue.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ConstraintExpEqualsValue.java
@@ -62,8 +62,6 @@ public final class ConstraintExpEqualsValue extends ConstraintImpl {
 
             @Override
             public void update(Subject exp, EventOfInterest interest) throws Failure {
-                // Debug.on();Debug.print("ObserverEqualValue:
-                // "+interest);Debug.off();
                 var event = (IntEvent) interest;
                 if ((event.isValueEvent() && event.min() != _value) || (event.isMaxEvent() && event.max() < _value) || (event
                         .isMinEvent() && event.min() > _value)) {

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainBits.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainBits.java
@@ -32,16 +32,8 @@ import org.openl.ie.constrainer.IntVar;
  * @see Domain
  */
 public final class DomainBits extends DomainImpl {
-    // private IntVar _variable;
     private boolean[] _bits;
     private int _size;
-
-    // private int _initial_min;
-    // private int _initial_max;
-    // private int _min; // the first i with _bits[i]=true
-    // private int _max; // the last i with _bits[i]=true
-
-    // public static final int MAX_VALUE = 1000000;//Integer.MAX_VALUE-1;
 
     public DomainBits(IntVar var, int min, int max) // throws Failure
     {
@@ -49,7 +41,6 @@ public final class DomainBits extends DomainImpl {
         _bits = new boolean[max - min + 1];
         Arrays.fill(_bits, true);
         _size = _max - _min + 1;
-        // check("constructor");
     }
 
     public boolean[] bits() {
@@ -74,12 +65,6 @@ public final class DomainBits extends DomainImpl {
     public void forceInsert(int val) {
         _bits[val - _initial_min] = true;
     }
-
-    /*
-     * catch(Exception ex) { System.out.println("Error: length: " + _bits.length + " _initialMin: " + _initial_min + "
-     * _initialMax: " + _initial_max + " _min: " + _min + " _max: " + _max + " value: " + value ); System.exit(1);
-     * return false; }
-     */
 
     @Override
     public void forceSize(int val) {
@@ -177,15 +162,9 @@ public final class DomainBits extends DomainImpl {
     @Override
     public boolean removeValue(int value) throws Failure {
 
-        // System.out.println("Before Remove: " + value + " this=" + this);
         if (!contains(value)) {
             return false;
         }
-
-        // if (size() <= 1)
-        // {
-        // constrainer().fail("remove");
-        // }
 
         if (value == _min) {
             return setMin(value + 1);
@@ -194,13 +173,11 @@ public final class DomainBits extends DomainImpl {
             return setMax(value - 1);
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         _bits[value - _initial_min] = false;
         --_size;
 
-        // System.out.println("After Remove: " + value + " this=" + this);
         return true;
     }
 
@@ -214,10 +191,7 @@ public final class DomainBits extends DomainImpl {
             constrainer().fail("Max < Min ");
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
-
-        // _max = M;
 
         while (_max > M) {
             if (_bits[_max-- - _initial_min]) {
@@ -231,15 +205,9 @@ public final class DomainBits extends DomainImpl {
             }
         }
 
-        // check("setMax(" + M + ")");
         return true;
 
     }
-
-    /*
-     * public String toString() { return "[" + _initial_min + ":" + _min + ";" + _max + ":" + _initial_max + "]" +
-     * " bits: " + printBits() + " size: " + size(); }
-     */
 
     @Override
     public boolean setMin(int m) throws Failure {
@@ -251,10 +219,7 @@ public final class DomainBits extends DomainImpl {
             constrainer().fail("Min > Max ");
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
-
-        // _min = m;
 
         while (_min < m) {
             if (_bits[_min++ - _initial_min]) {
@@ -268,7 +233,6 @@ public final class DomainBits extends DomainImpl {
             }
         }
 
-        // check("setMin(" + m + ")");
         return true;
 
     }
@@ -276,7 +240,6 @@ public final class DomainBits extends DomainImpl {
     @Override
     public boolean setValue(int value) throws Failure {
         if (_min == value && _max == value) {
-            // constrainer().fail("Redundant value "+_variable);
             return false;
         }
 
@@ -284,13 +247,11 @@ public final class DomainBits extends DomainImpl {
             constrainer().fail("attempt to set invalid value");
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         _min = value;
         _max = value;
         _size = 1;
-        // check("setValue(" + value + ")");
         return true;
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainBits2.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainBits2.java
@@ -25,17 +25,13 @@ final class BitArray implements Serializable {
     }
 
     boolean at(int index) {
-        // return (_bits[index/BITS_PER_WORD] & (1 << index % BITS_PER_WORD)) !=
-        // 0 ;
         return (_bits[index / BITS_PER_WORD] & 1 << index) != 0;
     }
 
     void set(int index, boolean val) {
         if (val) {
-            // _bits[index/BITS_PER_WORD] |= (1 << index % BITS_PER_WORD);
             _bits[index / BITS_PER_WORD] |= 1 << index;
         } else {
-            // _bits[index/BITS_PER_WORD] &= ~(1 << index % BITS_PER_WORD);
             _bits[index / BITS_PER_WORD] &= ~(1 << index);
         }
     }
@@ -74,7 +70,6 @@ public final class DomainBits2 extends DomainImpl {
         super(var, min, max);
         _size = _max - _min + 1;
         _bits = new BitArray(_size);
-        // check("constructor");
     }
 
     public int[] bits() {
@@ -90,12 +85,6 @@ public final class DomainBits2 extends DomainImpl {
 
         return _bits.at(value - _initial_min);
     }
-
-    /*
-     * catch(Exception ex) { System.out.println("Error: length: " + _bits.length + " _initialMin: " + _initial_min + "
-     * _initialMax: " + _initial_max + " _min: " + _min + " _max: " + _max + " value: " + value ); System.exit(1);
-     * return false; }
-     */
 
     public void forceBits(int[] bits) {
         _bits._bits = bits;
@@ -161,15 +150,9 @@ public final class DomainBits2 extends DomainImpl {
     @Override
     public boolean removeValue(int value) throws Failure {
 
-        // System.out.println("Before Remove: " + value + " this=" + this);
         if (!contains(value)) {
             return false;
         }
-
-        /*
-         * if (size() <= 1) { constrainer().fail("remove"); }
-         *
-         */
 
         if (value == _min) {
             return setMin(value + 1);
@@ -178,13 +161,11 @@ public final class DomainBits2 extends DomainImpl {
             return setMax(value - 1);
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         _bits.set(value - _initial_min, false);
         --_size;
 
-        // System.out.println("After Remove: " + value + " this=" + this);
         return true;
     }
 
@@ -198,10 +179,7 @@ public final class DomainBits2 extends DomainImpl {
             constrainer().fail("Max < Min");
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
-
-        // _max = M;
 
         while (_max > M) {
             if (_bits.at(_max-- - _initial_min)) {
@@ -215,15 +193,9 @@ public final class DomainBits2 extends DomainImpl {
             }
         }
 
-        // check("setMax(" + M + ")");
         return true;
 
     }
-
-    /*
-     * public String toString() { return "[" + _initial_min + ":" + _min + ";" + _max + ":" + _initial_max + "]" +
-     * " bits: " + printBits() + " size: " + size(); }
-     */
 
     @Override
     public boolean setMin(int m) throws Failure {
@@ -235,10 +207,7 @@ public final class DomainBits2 extends DomainImpl {
             constrainer().fail("Min > Max");
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
-
-        // _min = m;
 
         while (_min < m) {
             if (_bits.at(_min++ - _initial_min)) {
@@ -252,7 +221,6 @@ public final class DomainBits2 extends DomainImpl {
             }
         }
 
-        // check("setMin(" + m + ")");
         return true;
 
     }
@@ -260,7 +228,6 @@ public final class DomainBits2 extends DomainImpl {
     @Override
     public boolean setValue(int value) throws Failure {
         if (_min == value && _max == value) {
-            // constrainer().fail("Redundant value "+_variable);
             return false;
         }
 
@@ -268,13 +235,11 @@ public final class DomainBits2 extends DomainImpl {
             constrainer().fail("attempt to set invalid value");
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         _min = value;
         _max = value;
         _size = 1;
-        // check("setValue(" + value + ")");
         return true;
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainImpl.java
@@ -27,8 +27,6 @@ public class DomainImpl implements Domain {
         _variable = var;
         _initial_min = min;
         _initial_max = max;
-        // int size = max-min+1;
-        // if (size<1) throw new Failure("max < min?");
         _min = min;
         _max = max;
     }
@@ -47,16 +45,9 @@ public class DomainImpl implements Domain {
     public void forceInsert(int val) {
     }
 
-    /*
-     * public Set set() { Set elements = new HashSet(); for(int i=0; i<_values.size(); i++) { DomainInterval interval =
-     * (DomainInterval)_values.elementAt(i); for(int v=interval.from; v<=interval.to; ++v) { elements.add(new
-     * Integer(v)); } } return elements; }
-     */
-
     @Override
     public void forceMax(int max) {
         _max = max;
-        // check("forceMax(" + max + ")");
     }
 
     @Override
@@ -110,14 +101,11 @@ public class DomainImpl implements Domain {
     // Prohibited in this implementation!
     @Override
     public boolean removeValue(int value) throws Failure {
-        // Debug.print(this+".removeValue("+value+")");
         if (value == min()) {
             return setMin(value + 1);
         } else if (value == max()) {
             return setMax(value - 1);
         }
-        // System.out.println("Method removeValue is prohibited for this
-        // implementation");
         return false;
     }
 
@@ -127,16 +115,10 @@ public class DomainImpl implements Domain {
             return false;
         }
         if (M < _min) {
-            // Debug.print("Attempt to set max to "+M+" for "+_variable);
-            // if (constrainer().showFailures())
-            // constrainer().fail("Attempt to set max to "+M+" for "+_variable);
-            // else
             constrainer().fail("DomainImpl setMax");
         }
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
         _max = M;
-        // check("setMax(" + M + ")");
         return true;
     }
 
@@ -146,40 +128,26 @@ public class DomainImpl implements Domain {
             return false;
         }
         if (m > _max) {
-            // Debug.print("Attempt to set min to "+m+" for "+_variable);
-            // if (constrainer().showFailures())
-            // constrainer().fail("Attempt to set min to "+m+" for "+_variable);
-            // else
             constrainer().fail("DomainImpl setMin");
         }
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
         _min = m;
-        // check("setMin(" + m + ")");
         return true;
     }
 
     @Override
     public boolean setValue(int value) throws Failure {
-        // Debug.print("setValue " + value);
         if (_min == value && _max == value) {
-            // constrainer().fail("Redundant value "+_variable);
             return false;
         }
 
         if (!contains(value)) {
-            // if (constrainer().showFailures())
-            // constrainer().fail("Attempt to set value to "+value+" for
-            // "+_variable);
-            // else
             constrainer().fail("DomainImpl setValue");
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
         _min = value;
         _max = value;
-        // check("setValue(" + value + ")");
         return true;
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainImplWithHoles.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainImplWithHoles.java
@@ -63,15 +63,11 @@ public final class DomainImplWithHoles extends DomainImpl {
 
     @Override
     public int max() {
-        // DomainInterval interval = (DomainInterval)_values.lastElement();
-        // return interval.to;
         return _max;
     }
 
     @Override
     public int min() {
-        // DomainInterval interval = (DomainInterval)_values.firstElement();
-        // return interval.from;
         return _min;
     }
 
@@ -84,7 +80,6 @@ public final class DomainImplWithHoles extends DomainImpl {
             return setMax(value - 1);
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         for (var i = 0; i < _values.size(); i++) {
@@ -123,7 +118,6 @@ public final class DomainImplWithHoles extends DomainImpl {
             constrainer().fail("Max < Min for " + _variable);
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         // remove a hole
@@ -159,7 +153,6 @@ public final class DomainImplWithHoles extends DomainImpl {
             constrainer().fail("Min > Max for " + _variable);
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         // remove hole
@@ -186,9 +179,7 @@ public final class DomainImplWithHoles extends DomainImpl {
 
     @Override
     public boolean setValue(int value) throws Failure {
-        // Debug.print("setValue " + value);
         if (_min == value && _max == value) {
-            // constrainer().fail("Redundant value "+_variable);
             return false;
         }
 
@@ -196,7 +187,6 @@ public final class DomainImplWithHoles extends DomainImpl {
             constrainer().fail("attempt to set invalid value for " + _variable);
         }
 
-        // constrainer().addUndo(_variable);
         _variable.addUndo();
 
         _values.clear();
@@ -218,8 +208,6 @@ public final class DomainImplWithHoles extends DomainImpl {
 
     @Override
     public String toString() {
-        // return "["+min()+((size()==1) ? "" : ";"+max())+"]"
-        // +((values().size()==1)?"":"-"+values().size()+"intervals");
         return _values.toString();
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ExpressionFactoryImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ExpressionFactoryImpl.java
@@ -271,7 +271,6 @@ public final class ExpressionFactoryImpl extends UndoableOnceImpl implements Exp
 
         if (exp == null) {
             exp = createExpression(clazz, args, types);
-            // System.out.println("Creating new expression: " + exp.name());
             if (_putInCache) {
                 addUndo();
                 _expressions.put(key, exp);

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ExpressionObserver.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ExpressionObserver.java
@@ -71,7 +71,6 @@ public abstract class ExpressionObserver extends Observer {
      */
     static final private int[] trival_event_map = {MIN, MIN, MAX, MAX, VALUE, VALUE, REMOVE, REMOVE};
 
-    // protected Expression _expression;
     private final EventMap _event_map;
 
     /**
@@ -94,15 +93,6 @@ public abstract class ExpressionObserver extends Observer {
         _event_map = new EventMapImpl(masks);
     }
 
-    // /**
-    // * Returns an event map for this observer.
-    // */
-    // public EventMap eventMap()
-    // {
-    // return _event_map;
-    // }
-    //
-
     /**
      * Subscribes for the events from "exp" with a given "publishMask".
      * <p>
@@ -124,9 +114,6 @@ public abstract class ExpressionObserver extends Observer {
     @Override
     public void subscriberMask(int mask, Subject subj) {
         if (_subscriber_mask != mask) {
-            // Debug.on();Debug.print("" + this + " mask: "+ mask + " exp:" +
-            // expression);Debug.off();
-
             _subscriber_mask = mask;
         }
 
@@ -169,7 +156,6 @@ public abstract class ExpressionObserver extends Observer {
 
     @Override
     public void update(Subject exp, EventOfInterest event) throws Failure {
-        // Debug.on();Debug.print("" + this + " : "+event);Debug.off();
         if (event.isValueEvent()) {
             transformValueEvent(event);
         } else if (event.isMinEvent()) {

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolExpEqValue.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolExpEqValue.java
@@ -72,9 +72,4 @@ public final class IntBoolExpEqValue extends IntBoolExpForSubject {
         _exp.setValue(_value);
     }
 
-    // public Constraint asConstraint()
-    // {
-    // return _exp.equals(_value);
-    // }
-
 } // ~IntBoolExpEqValue

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolExpForSubject.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolExpForSubject.java
@@ -61,9 +61,6 @@ public abstract class IntBoolExpForSubject extends IntBoolVarImpl {
      * Sets the domain of this expression based on isSubjectTrue()/isSubjectFalse().
      */
     protected void setDomainMinMax() throws Failure {
-        // if(_subjectMin.value() > _subjectMax.value())
-        // abort("_subjectMin.value() > _subjectMax.value() in " + this);
-
         if (_subjectMin.value() == _subjectMax.value()) {
             return;
         }
@@ -75,9 +72,6 @@ public abstract class IntBoolExpForSubject extends IntBoolVarImpl {
             _subjectMin.setValue(1);
         }
 
-        // if(_subjectMin.value() > _subjectMax.value())
-        // abort("_subjectMin.value() > _subjectMax.value() in " + this);
-
         // Subject is bound -> update constraint domain.
         if (_subjectMin.value() == _subjectMax.value()) {
             super.setValue(_subjectMin.value());
@@ -85,12 +79,8 @@ public abstract class IntBoolExpForSubject extends IntBoolVarImpl {
         // Subject is not bound -> propagate constraint domain.
         else {
             if (isTrue()) {
-                // System.out.println("setDomainMinMax(): setSubjectTrue():
-                // "+this);
                 setSubjectTrue();
             } else if (isFalse()) {
-                // System.out.println("setDomainMinMax(): setSubjectFalse():
-                // "+this);
                 setSubjectFalse();
             }
         }
@@ -118,44 +108,26 @@ public abstract class IntBoolExpForSubject extends IntBoolVarImpl {
 
     @Override
     public void setMax(int max) throws Failure {
-        // System.out.println("+++IntBoolExpForSubject.setMax(" +max + ") in " +
-        // this);
-
         if (max >= max()) {
             return;
         }
 
         super.setMax(max);
 
-        // if(max < 0)
-        // constrainer().fail("Constraint.setMax() < 0");
-
         // max==0 -> setFalse
         setSubjectFalse();
-
-        // System.out.println("---IntBoolExpForSubject.setMax(" +max + ") in " +
-        // this);
     }
 
     @Override
     public void setMin(int min) throws Failure {
-        // System.out.println("+++IntBoolExpForSubject.setMin(" +min + ") in " +
-        // this);
-
         if (min <= min()) {
             return;
         }
 
         super.setMin(min);
 
-        // if(min > 1)
-        // constrainer().fail("Constraint.setMin() > 1");
-
         // min==1 -> setTrue
         setSubjectTrue();
-
-        // System.out.println("---IntBoolExpForSubject.setMin(" +min + ") in " +
-        // this);
     }
 
     /**

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolExpImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolExpImpl.java
@@ -37,7 +37,6 @@ abstract public class IntBoolExpImpl extends IntExpImpl implements IntBoolExp {
 
     @Override
     public IntBoolExp and(IntBoolExp exp) {
-        // return new IntBoolExpAnd(this, exp);
         return getIntBoolExp(IntBoolExpAnd.class, this, exp);
     }
 
@@ -63,7 +62,6 @@ abstract public class IntBoolExpImpl extends IntExpImpl implements IntBoolExp {
 
     @Override
     public IntBoolExp or(IntBoolExp exp) {
-        // return new IntBoolExpOr(this, exp);
         return getIntBoolExp(IntBoolExpOr.class, this, exp);
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolVarImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntBoolVarImpl.java
@@ -341,15 +341,11 @@ public class IntBoolVarImpl extends IntBoolExpImpl implements IntBoolVar {
         }
 
         if (max < _max) {
-            // addUndo();
-            // if(!undone())
             constrainer().addUndo(UndoIntBoolVarValue.getUndo(this));
 
             _max = max;
 
             notifyObservers(IntEventBoolFalse.the);
-            // notifyObservers(IntEventBool.getEvent(this, false));
-            // addToPropagationQueue();
         }
     }
 
@@ -360,15 +356,11 @@ public class IntBoolVarImpl extends IntBoolExpImpl implements IntBoolVar {
         }
 
         if (min > _min) {
-            // addUndo();
-            // if(!undone())
             constrainer().addUndo(UndoIntBoolVarValue.getUndo(this));
 
             _min = min;
 
             notifyObservers(IntEventBoolTrue.the);
-            // notifyObservers(IntEventBool.getEvent(this, true));
-            // addToPropagationQueue();
         }
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntDomainHistory.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntDomainHistory.java
@@ -173,14 +173,8 @@ public final class IntDomainHistory implements Serializable {
 
     void propagate() throws Failure {
 
-        // System.out.println("+++ Propagate: " + _var + this + " pubMask:" +
-        // _var.publisherMask());
-
         if ((_var.publisherMask() & _mask) != 0) {
-            // System.out.println("--- Propagate: " + _var + _history + ":" +
-            // _currentIndex );
             IntEventDomain ev = IntEventDomain.getEvent(this);
-            // _mask = 0;
             save();
             _var.notifyObservers(ev);
         } else {

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddArray.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddArray.java
@@ -16,7 +16,6 @@ public final class IntExpAddArray extends IntExpImpl {
     class ExpAddVectorObserver extends Observer {
 
         ExpAddVectorObserver() {
-            // super(event_map);
         }
 
         @Override
@@ -37,8 +36,6 @@ public final class IntExpAddArray extends IntExpImpl {
         @Override
         public void update(Subject exp, EventOfInterest event) throws Failure {
             var e = (IntEvent) event;
-
-            // System.out.println("Event:" + e);
 
             _sum.setMin(_sum.min() + e.mindiff());
             _sum.setMax(_sum.max() + e.maxdiff());
@@ -147,12 +144,6 @@ public final class IntExpAddArray extends IntExpImpl {
 
     @Override
     public void onMaskChange() {
-        // int mask = publisherMask();
-        // IntExp[] data =_vars.data();
-        // for(int i=0; i < data.length; i++)
-        // {
-        // _observer.publish(mask,data[i]);
-        // }
     }
 
     @Override
@@ -189,8 +180,6 @@ public final class IntExpAddArray extends IntExpImpl {
             return;
         }
 
-        // System.out.println("++++ Set max: " + max + " in " + this);
-
         var min_sum = min();
 
         var vars = _vars.data();
@@ -201,7 +190,6 @@ public final class IntExpAddArray extends IntExpImpl {
                 vari.setMax(maxi);
             }
         }
-        // System.out.println("---- set max:" + max + " in " + this);
     }
 
     @Override
@@ -210,8 +198,6 @@ public final class IntExpAddArray extends IntExpImpl {
         if (min <= min()) {
             return;
         }
-
-        // System.out.println("++++ Set min: " + min + " in " + this);
 
         var max_sum = max();
 
@@ -223,7 +209,6 @@ public final class IntExpAddArray extends IntExpImpl {
                 vari.setMin(mini);
             }
         }
-        // System.out.println("---- set min:" + min + " in " + this);
     }
 
     @Override
@@ -244,8 +229,6 @@ public final class IntExpAddArray extends IntExpImpl {
             return;
         }
 
-        // System.out.println("++++ Set value: " + value + " in " + this);
-
         var vars = _vars.data();
 
         for (IntExp vari : vars) {
@@ -262,8 +245,6 @@ public final class IntExpAddArray extends IntExpImpl {
                 vari.setMax(new_max);
             }
         }
-
-        // System.out.println("---- set value: " + value + " in " + this);
     }
 
     @Override

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddArray1.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddArray1.java
@@ -29,7 +29,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
     class ExpAddVectorObserver extends Observer {
 
         ExpAddVectorObserver() {
-            // super(event_map);
         }
 
         @Override
@@ -50,8 +49,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
         @Override
         public void update(Subject exp, EventOfInterest event) throws Failure {
             var e = (IntEvent) event;
-
-            // System.out.println("Event:" + e);
 
             _domainE.setMin(_domainE.min() + e.mindiff());
             _domainE.setMax(_domainE.max() + e.maxdiff());
@@ -148,8 +145,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
         var maxE = _domainE.max();
 
         if (minC == minE && maxC == maxE) {
-            // System.out.println("*** enforceDomainC():
-            // ["+minE+".."+maxE+"]->["+minC+".."+maxC+"]");
             return;
         }
 
@@ -199,12 +194,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
 
     @Override
     public void onMaskChange() {
-        // int mask = publisherMask();
-        // IntExp[] data =_vars.data();
-        // for(int i=0; i < data.length; i++)
-        // {
-        // _observer.publish(mask,data[i]);
-        // }
     }
 
     @Override
@@ -243,8 +232,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
 
         _domainC.setMax(max);
 
-        // System.out.println("++++ Set max: " + max + " in " + this);
-
         var min_sum = _domainE.min();
 
         var vars = _vars.data();
@@ -255,7 +242,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
                 vari.setMax(maxi);
             }
         }
-        // System.out.println("---- set max:" + max + " in " + this);
     }
 
     @Override
@@ -267,8 +253,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
 
         _domainC.setMin(min);
 
-        // System.out.println("++++ Set min: " + min + " in " + this);
-
         var max_sum = _domainE.max();
 
         var vars = _vars.data();
@@ -279,7 +263,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
                 vari.setMin(mini);
             }
         }
-        // System.out.println("---- set min:" + min + " in " + this);
     }
 
     @Override
@@ -289,8 +272,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
         }
 
         _domainC.setValue(value);
-
-        // System.out.println("++++ Set value: " + value + " in " + this);
 
         var sum_min = _domainE.min();
         var sum_max = _domainE.max();
@@ -311,8 +292,6 @@ public final class IntExpAddArray1 extends IntExpImpl {
                 vari.setMax(new_max);
             }
         }
-
-        // System.out.println("---- set value: " + value + " in " + this);
     }
 
     @Override

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddExp.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddExp.java
@@ -17,7 +17,6 @@ import org.openl.ie.constrainer.Subject;
 public final class IntExpAddExp extends IntExpImpl {
     class ExpAddExpObserver extends Observer {
         ExpAddExpObserver() {
-            // super(event_map);
         }
 
         @Override
@@ -37,13 +36,8 @@ public final class IntExpAddExp extends IntExpImpl {
 
         @Override
         public void update(Subject exp, EventOfInterest event) throws Failure {
-            // IntEvent e = (IntEvent) event;
-
-            // int type = e.type();
-            // if ((type & MIN) != 0)
             _sum.setMin(calc_min());
 
-            // if ((type & MAX) != 0)
             _sum.setMax(calc_max());
 
         }
@@ -53,11 +47,6 @@ public final class IntExpAddExp extends IntExpImpl {
     private final IntExp _exp1;
 
     private final IntExp _exp2;
-
-    // static final private int[] event_map = { MIN, MIN,
-    // MAX, MAX,
-    // MIN | MAX | VALUE, VALUE
-    // };
 
     private final Observer _observer;
 
@@ -73,7 +62,6 @@ public final class IntExpAddExp extends IntExpImpl {
         _exp1 = exp1;
         _exp2 = exp2;
 
-        // int trace = IntVarImplTrace.TRACE_ALL;
         _sum = constrainer().addIntVarTraceInternal(calc_min(), calc_max(), _name, IntVar.DOMAIN_PLAIN);
 
         _observer = new ExpAddExpObserver();
@@ -118,8 +106,6 @@ public final class IntExpAddExp extends IntExpImpl {
 
     @Override
     public void onMaskChange() {
-        // _observer.publish(publisherMask(), _exp1);
-        // _observer.publish(publisherMask(), _exp2);
     }
 
     @Override

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddValue.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpAddValue.java
@@ -179,8 +179,6 @@ public final class IntExpAddValue extends IntExpImpl {
     @Override
     public void setMin(int min) throws Failure {
 
-        // System.out.println("++++ Set min: " + min + " in " + this);
-
         _exp.setMin(min - _value);
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpCard.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpCard.java
@@ -37,9 +37,6 @@ public final class IntExpCard extends IntExpImpl {
 
         @Override
         public void update(Subject var, EventOfInterest interest) throws Failure {
-            // Debug.on();Debug.print("ObserverPossibleRequired
-            // "+interest);Debug.off();
-
             // any _possible event may produce only decrease in size
             _possible_required.setMax(_indexes.size() - 1);
 
@@ -53,12 +50,8 @@ public final class IntExpCard extends IntExpImpl {
     private final int _card_value;
 
     public IntExpCard(Constrainer constrainer, IntExpArray vars, int card_value) throws Failure {
-        // super(constrainer,0,vars.size(),"C" + card_value,
-        // IntVarImplTrace.TRACE_ALL);
         super(constrainer, "C" + card_value);
         _card_value = card_value;
-
-        // int trace = IntVarImplTrace.TRACE_ALL;
 
         int size = vars.size();
         _vars = vars;
@@ -86,12 +79,6 @@ public final class IntExpCard extends IntExpImpl {
         );
 
         _indexes.attachObserver(new ObserverIndexes());
-
-        // _possible_required.attachObserver(new ObserverPossibleRequired());
-        // constrainer().trace(_possible_required);
-        // constrainer().trace(this);
-
-        // this.attachObserver(new ObserverCardValue());
 
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpImpl.java
@@ -40,13 +40,11 @@ public abstract class IntExpImpl extends ExpressionImpl implements IntExp {
 
     @Override
     public IntExp add(int value) {
-        // return new IntExpAddValue(this,value);
         return getIntExp(IntExpAddValue.class, this, value);
     }
 
     @Override
     public IntExp add(IntExp exp) {
-        // return new IntExpAddExp(this,exp);
         return getIntExp(IntExpAddExp.class, this, exp);
     }
 
@@ -68,7 +66,6 @@ public abstract class IntExpImpl extends ExpressionImpl implements IntExp {
 
     @Override
     public IntBoolExp eq(int value) {
-        // return new IntBoolExpEqValue(this, value);
         return getIntBoolExp(IntBoolExpEqValue.class, this, value);
     }
 
@@ -85,13 +82,11 @@ public abstract class IntExpImpl extends ExpressionImpl implements IntExp {
 
     @Override
     public IntBoolExp gt(int value) {
-        // return gt(new IntExpConst(_constrainer, value));
         return gt(getIntExp(IntExpConst.class, value));
     }
 
     @Override
     public IntBoolExp gt(IntExp exp) {
-        // return new IntBoolExpLessExp(exp, this);
         return getIntBoolExp(IntBoolExpLessExp.class, exp, this);
     }
 
@@ -119,13 +114,11 @@ public abstract class IntExpImpl extends ExpressionImpl implements IntExp {
 
     @Override
     public IntBoolExp lt(int value) {
-        // return lt(new IntExpConst(_constrainer, value));
         return lt(getIntExp(IntExpConst.class, value));
     }
 
     @Override
     public IntBoolExp lt(IntExp exp) {
-        // return new IntBoolExpLessExp(this,exp);
         return getIntBoolExp(IntBoolExpLessExp.class, this, exp);
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntVarImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntVarImpl.java
@@ -50,10 +50,8 @@ public class IntVarImpl extends IntExpImpl implements IntVar {
         @Override
         public void undo() {
             var intvar = (IntVarImpl) undoable();
-            // System.out.println("++ Undo: " + intvar);
             intvar.history().restore(_history_index);
             super.undo();
-            // System.out.println("-- Undo: " + intvar);
         }
 
         @Override
@@ -61,8 +59,6 @@ public class IntVarImpl extends IntExpImpl implements IntVar {
             super.undoable(u);
             var intvar = (IntVarImpl) u;
             _history_index = intvar.history().currentIndex();
-            // System.out.println("++ SAVE: " + intvar + "index:" +
-            // _history_index);
 
         }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/SubjectImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/SubjectImpl.java
@@ -203,7 +203,6 @@ public abstract class SubjectImpl extends UndoableOnceImpl implements Subject {
 
     @Override
     public void attachObserver(Observer observer) {
-        // Debug.on(); Debug.print(this + " Attach: " + observer); Debug.off();
         _observers.addElement(observer);
         publisherMask(_publisher_mask | observer.subscriberMask());
         constrainer().addUndo(UndoAttachObserver.getUndo(this, observer));
@@ -217,22 +216,17 @@ public abstract class SubjectImpl extends UndoableOnceImpl implements Subject {
     @Override
     public void detachObserver(Observer observer) {
 
-        // Debug.on(); Debug.print(this + " Detach: " + observer); Debug.off();
         _observers.removeElement(observer);
         constrainer().addUndo(UndoDetachObserver.getUndo(this, observer));
     }
 
     @Override
     public void forcedAttachObserver(Observer observer) {
-        // Debug.on(); Debug.print(this + " AttachForced: " + observer);
-        // Debug.off();
         _observers.addElement(observer);
     }
 
     @Override
     public void forcedDetachObserver(Observer observer) {
-        // Debug.on(); Debug.print(this + " DetachForced: " + observer);
-        // Debug.off();
         _observers.removeElement(observer);
     }
 
@@ -248,16 +242,12 @@ public abstract class SubjectImpl extends UndoableOnceImpl implements Subject {
 
     @Override
     final public void notifyObservers(EventOfInterest interest) throws Failure {
-        // Debug.on(); Debug.print("* "+interest); Debug.off();
-        // FastVector observers = (FastVector)_observers.clone();
         var observers = _observers;
         _constrainer.incrementNumberOfNotifications();
         var size = observers.size();
         for (var i = 0; i < size; ++i) {
             var observer = (Observer) observers.elementAt(i);
             if (observer.interestedIn(interest)) {
-                // Debug.on(); Debug.print("Observer "+i+":
-                // "+observer);Debug.off();
                 observer.update(this, interest);
             }
         }
@@ -284,8 +274,6 @@ public abstract class SubjectImpl extends UndoableOnceImpl implements Subject {
     public void publisherMask(int mask) {
 
         if (mask != _publisher_mask) {
-            // System.out.println("Pub Mask: " + mask + " for: " + this + "
-            // old:" + _publisher_mask);
             _publisher_mask = mask;
             onMaskChange();
             addUndo();
@@ -331,12 +319,6 @@ public abstract class SubjectImpl extends UndoableOnceImpl implements Subject {
                 return null;
             }
 
-            /*
-             * public boolean interestedIn(EventOfInterest event) { switch(_event_type) { case EventOfInterest.MAX:
-             * return event.isMaxEvent(); case EventOfInterest.MIN: return event.isMinEvent(); case
-             * EventOfInterest.VALUE: return event.isValueEvent(); case EventOfInterest.REMOVE: return
-             * event.isRemoveEvent(); } return true; }
-             */
             @Override
             public int subscriberMask() {
                 return _event_type;

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/UndoableImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/UndoableImpl.java
@@ -34,7 +34,6 @@ public abstract class UndoableImpl extends ConstrainerObjectImpl implements Undo
     public void addUndo() {
         var undo_object = createUndo();
         undo_object.undoable(this);
-        // Debug.on();Debug.print("add " + undo_object);Debug.off();
         constrainer().addUndo(undo_object);
     }
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/UndoableOnceImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/UndoableOnceImpl.java
@@ -46,8 +46,6 @@ public abstract class UndoableOnceImpl extends ConstrainerObjectImpl implements 
             _undone = true;
             var undo_object = createUndo();
             undo_object.undoable(this);
-            // Debug.on();Debug.print("add " + undo_object);Debug.off();
-            // constrainer().addUndo(undo_object);
             constrainer().addUndo(undo_object, this);
         }
     }

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/tools/FastVector.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/tools/FastVector.java
@@ -73,8 +73,6 @@ public final class FastVector implements Cloneable, Serializable {
         try {
             var v = (FastVector) super.clone();
             v.m_data = m_data.clone();
-            // v.m_data = new Object[m_data.length];
-            // System.arraycopy(m_data, 0, v.m_data, 0, m_data.length);
             return v;
         } catch (CloneNotSupportedException e) {
             // this shouldn't happen, since we are Cloneable

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/tools/FastVectorInt.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/tools/FastVectorInt.java
@@ -42,7 +42,6 @@ public final class FastVectorInt implements Cloneable, Serializable {
 
     public void clear() {
         m_size = 0;
-        // m_data = new Object[m_data.length];
     }
 
     @Override
@@ -50,8 +49,6 @@ public final class FastVectorInt implements Cloneable, Serializable {
         try {
             var v = (FastVectorInt) super.clone();
             v.m_data = m_data.clone();
-            // v.m_data = new int[m_data.length];
-            // System.arraycopy(m_data, 0, v.m_data, 0, m_data.length);
             return v;
         } catch (CloneNotSupportedException e) {
             // this shouldn't happen, since we are Cloneable

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/tools/ReusableImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/tools/ReusableImpl.java
@@ -32,10 +32,8 @@ public class ReusableImpl implements Reusable {
     public ReusableImpl() {
     }
 
-    // public final void free()
     @Override
     public void free() {
-        // if (_factory != null)
         _factory.freeElement(this);
     }
 

--- a/DEV/org.openl.rules/src/org/openl/binding/impl/TypeBindingContext.java
+++ b/DEV/org.openl.rules/src/org/openl/binding/impl/TypeBindingContext.java
@@ -93,11 +93,9 @@ public class TypeBindingContext extends BindingContextDelegator {
                                           String name,
                                           IOpenClass[] parTypes) throws AmbiguousMethodException {
         IMethodCaller res = null;
-        // IOpenMethod method = null;
         if (namespace.equals(ISyntaxConstants.THIS_NAMESPACE)) {
             res = MethodSearch.findMethod(name, parTypes, this, localVar.getType(), true);
 
-            // method = localVar.getType().getMatchingMethod(name, parTypes);
             if (res != null) {
                 res = new LocalVarMethodCaller(localVar, res);
             }

--- a/DEV/org.openl.rules/src/org/openl/grammar/JavaCC30Grammar.java
+++ b/DEV/org.openl.rules/src/org/openl/grammar/JavaCC30Grammar.java
@@ -104,7 +104,6 @@ public abstract class JavaCC30Grammar implements IGrammar {
         // TODO exception?
         switch (stack.size()) {
             case 0:
-                // addError(new SyntaxException());
                 return null;
             case 1:
                 return pop();
@@ -122,8 +121,6 @@ public abstract class JavaCC30Grammar implements IGrammar {
                         null,
                         node);
                 return node;
-            // throw new RuntimeException("More than one syntax node on
-            // stack");
         }
     }
 

--- a/DEV/org.openl.rules/src/org/openl/grammar/JavaCC30Position.java
+++ b/DEV/org.openl.rules/src/org/openl/grammar/JavaCC30Position.java
@@ -46,7 +46,6 @@ public class JavaCC30Position implements IPosition {
         }
 
         var line = jcc30line - 1;
-        // int linePos = info.getPosition(line);
         var colPos = Math.min(info.getLine(line).length(), jcc30col - 1);
 
         return colPos + 1;

--- a/DEV/org.openl.rules/src/org/openl/rules/cmatch/algorithm/ScoreAlgorithmCompiler.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/cmatch/algorithm/ScoreAlgorithmCompiler.java
@@ -80,9 +80,6 @@ public class ScoreAlgorithmCompiler extends MatchAlgorithmCompiler {
         Class<?> retClass = retType.getInstanceClass();
         if (!(int.class == retClass) && !(Integer.class == retClass)) {
             var msg = "Score algorithm supports int or Integer return type only.";
-            // String uri =
-            // columnMatch.getTableSyntaxNode().getTableBody().getGridTable().getUri(0,
-            // 0);
             var uri = columnMatch.getSourceUrl();
             throw SyntaxNodeExceptionUtils.createError(msg, new StringSourceCodeModule(null, uri));
         }

--- a/DEV/org.openl.rules/src/org/openl/rules/constants/ConstantsTableBoundNode.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/constants/ConstantsTableBoundNode.java
@@ -107,12 +107,10 @@ public class ConstantsTableBoundNode implements IMemberBoundNode {
                     boolean noErrors;
                     CompositeMethod compositeMethod;
                     cxt.pushErrors();
-                    // cxt.pushMessages();
                     try {
                         compositeMethod = OpenLManager.makeMethod(openl, source, methodHeader, cxt);
                     } finally {
 
-                        // cxt.popMessages();
                         List<SyntaxNodeException> syntaxNodeExceptions = cxt.popErrors();
                         noErrors = syntaxNodeExceptions.isEmpty();
                         syntaxNodeExceptions.forEach(cxt::addError);

--- a/DEV/org.openl.rules/src/org/openl/rules/dt/validator/DecisionTableValidationResult.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/dt/validator/DecisionTableValidationResult.java
@@ -96,7 +96,6 @@ public class DecisionTableValidationResult implements IValidationResult {
     public boolean hasProblems() {
 
         return hasErrors() || hasWarnings();
-        // return overlappings != null && overlappings.length > 0 || uncovered != null && uncovered.length > 0;
     }
 
     public boolean hasErrors() {
@@ -140,10 +139,6 @@ public class DecisionTableValidationResult implements IValidationResult {
             validationResultDetails
                     .append("There is an uncovered case for values: %s\r\n".formatted(Arrays.asList(getUncovered())));
         }
-
-        // if (getOverlappings().length > 0) {
-        // validationResultDetails.append(String.format("There is an overlap: %s", Arrays.asList(getOverlappings())));
-        // }
 
         var maxCounter = 3;
         var cnt = 0;

--- a/DEV/org.openl.rules/src/org/openl/rules/dt/validator/ValidationAlgorithm.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/dt/validator/ValidationAlgorithm.java
@@ -64,14 +64,10 @@ public class ValidationAlgorithm {
             var cdt = new CDecisionTableImpl(expressions,
                     vars,
                     decisionTableToValidate.isOverrideAscending());
-            // System.out.println(" **** Checking " + decisionTable);
             var tableChecker = new DTCheckerImpl(cdt);
 
             List<Uncovered> completeness = tableChecker.checkCompleteness();
             List<Overlapping> overlappings = tableChecker.checkOverlappings();
-
-            // System.out.println("C: " + completeness);
-            // System.out.println("O:" + overlappings);
 
             result = new DecisionTableValidationResult(decisionTable,
                     overlappings.toArray(new Overlapping[0]),

--- a/DEV/org.openl.rules/src/org/openl/rules/table/GridTool.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/table/GridTool.java
@@ -360,10 +360,6 @@ public class GridTool {
         // clear cells for properties
         for (var prpCell = leftCell + 1; prpCell < leftCell + regionWidth; prpCell++) {
             actions.add(new UndoableClearAction(prpCell, headerRegion.getBottom() + 1, metaInfoWriter));
-            /*
-             * actions.add(new SetBorderStyleAction(prpCell, headerRegion.getBottom() + 1, makeNewPropStyle(grid,
-             * prpCell, headerRegion.getBottom() + 1, prpCell, regionWidth, null) ));
-             */
         }
 
         if (regionWidth >= 3) {

--- a/DEV/org.openl.rules/src/org/openl/rules/table/LogicalTableHelper.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/table/LogicalTableHelper.java
@@ -148,7 +148,6 @@ public class LogicalTableHelper {
         if (gt.getHeight() == nRows && gt.getWidth() == nColumns) {
             // TODO Light delegator
             return new SimpleLogicalTable(gt);
-            // return new LogicalTable(gt, nColumns, nRows);
         }
 
         int[] rowsOffset = new int[nRows + 1];

--- a/DEV/org.openl.rules/src/org/openl/rules/tbasic/runtime/AlgorithmErrorHelper.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/tbasic/runtime/AlgorithmErrorHelper.java
@@ -58,8 +58,6 @@ final class AlgorithmErrorHelper {
             return errorMethod.invoke(environment.getTbasicTarget(), null, environment);
         }
 
-        // throw new RuntimeException(String.format("Execution of algorithm
-        // failed: %s", error.getMessage()), error);
         throw RuntimeExceptionWrapper.wrap(error);
 
     }

--- a/DEV/org.openl.rules/src/org/openl/rules/tbasic/runtime/TBasicVMDataContext.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/tbasic/runtime/TBasicVMDataContext.java
@@ -24,7 +24,6 @@ public class TBasicVMDataContext {
                                Map<String, RuntimeOperation> labels,
                                boolean isMainMethod) {
         assert operations != null;
-        // assert operations.size() > 0;
         assert labels != null;
 
         this.operations = operations;

--- a/DEV/org.openl.rules/src/org/openl/types/impl/DynamicObject.java
+++ b/DEV/org.openl.rules/src/org/openl/types/impl/DynamicObject.java
@@ -92,7 +92,6 @@ public class DynamicObject implements IDynamicObject {
         public void printObject(Object obj, int newID, NicePrinter printer) {
             if (obj instanceof IDynamicObject dobj) {
                 printReference(dobj, newID, printer);
-                // printer.getBuffer().append(shortTypeName(dobj.getType().getName()));
                 printMap(dobj.getFieldValues(), null, printer);
                 return;
             }

--- a/STUDIO/org.openl.rules.tableeditor/js/TableEditor.js
+++ b/STUDIO/org.openl.rules.tableeditor/js/TableEditor.js
@@ -1185,17 +1185,6 @@ function initTableEditor(editorId, url, cellToEdit, actions, mode, editable) {
         [save_item, undo_item].each(function(item) {
             processItem(getItemId(editorId, item), hasItems);
         });
-       /* if (hasItems) {
-            window.onbeforeunload = function() {
-               // alert('not saved');
-           
-                return "Your changes have not been saved.";
-            };
-        } else { // remove handler if Save/Undo items are disabled
-           
-          //  window.onbeforeunload = function() {};
-           
-        }*/
     };
 
     tableEditor.redoStateUpdated = function(hasItems) {

--- a/STUDIO/org.openl.rules.tableeditor/js/tableeditor.all.js
+++ b/STUDIO/org.openl.rules.tableeditor/js/tableeditor.all.js
@@ -1417,17 +1417,6 @@ function initTableEditor(editorId, url, cellToEdit, actions, mode, editable) {
         [save_item, undo_item].each(function(item) {
             processItem(getItemId(editorId, item), hasItems);
         });
-       /* if (hasItems) {
-            window.onbeforeunload = function() {
-               // alert('not saved');
-           
-                return "Your changes have not been saved.";
-            };
-        } else { // remove handler if Save/Undo items are disabled
-           
-          //  window.onbeforeunload = function() {};
-           
-        }*/
     };
 
     tableEditor.redoStateUpdated = function(hasItems) {

--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/ui/tree/TableTreeNodeBuilder.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/ui/tree/TableTreeNodeBuilder.java
@@ -90,10 +90,6 @@ public class TableTreeNodeBuilder extends BaseTableTreeNodeBuilder {
      */
     @Override
     public String getType(Object nodeObject) {
-        /*
-         * TableSyntaxNode tableSyntaxNode = (TableSyntaxNode) nodeObject; return IProjectTypes.PT_FOLDER + "." +
-         * tableSyntaxNode.getType();
-         */
         return IProjectTypes.PT_FOLDER;
     }
 

--- a/STUDIO/org.openl.rules.webstudio/webapp/css/common.css
+++ b/STUDIO/org.openl.rules.webstudio/webapp/css/common.css
@@ -530,7 +530,6 @@ ul.enum li {
 .editable-inner .editable-link-inner {
     visibility: hidden;
     opacity: 0;
-    /*padding-left: 4px;*/
     padding-right: 4px;
     transition: visibility 0.1s linear, opacity 0.2s ease-out;
 }


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Dead-code sweep. One commit per change type, each spanning the whole repository.

`git log --oneline main..HEAD | wc -l` → 2    `git diff --shortstat main..HEAD` → 58 files changed, 417 deletions(-)

Both commits were rewritten by a later sweep run (extra findings folded into the first with `--fixup`), so CI re-ran and any earlier approval was dismissed. Nothing in the review record below has changed.

**Whole-PR proof.** Every touched file was compared at both ends of the diff with all comments stripped: for all 58 files the remaining code is byte-identical, so the two commits together change no executable line. `git diff --numstat` also adds 0 lines across the PR.

## 1. Remove commented-out statements left in production Java sources

55 files, 394 deletions. Debug prints (`Debug.print`, `System.out.println`), abandoned alternatives kept beside the live code, guards that were switched off, and four disabled method bodies — as both `//` runs and `/* */` blocks. 42 files are in `DEV/org.openl.rules.constrainer`, 12 in `DEV/org.openl.rules`, 1 in `STUDIO/org.openl.rules.webstudio`.

**Evidence.** All 4033 `.java` files were parsed twice: once for maximal runs of consecutive `//` lines (344 lines shipped) and once for all 6511 `/* */` block comments (50 lines shipped). String literals, char literals and text blocks are consumed as literals, so a text block holding `rules/*.xlsx` cannot be mistaken for a comment opener. A run or block counts as commented-out code only when at least one line parses as a Java statement and no line reads as prose — so a `// TODO`, a `// FIXME`, an explanation or a divider keeps its whole run — and Javadoc was never a candidate. Every surviving run was then read individually against its surrounding code.

**Verification.** The full reactor was built with tests at this head: `mvn install -Dquick -DnoPerf -T1C`, BUILD SUCCESS over 75 modules and 533 test suites with no failure or error, plus `mvn validate -N` for the format check and no Spotless churn afterwards. A separate check confirmed no new blank-line artefact — the counts of `{`-then-blank, blank-then-`}` and double-blank lines per file are the same or lower than before. `org.openl.rules.webstudio` cannot be built in that environment (the OpenSAML artifacts it needs are not on Maven Central), so for its single file the GitHub Actions `Build artifacts` job is the compile gate.

**Kept deliberately** — the runs and blocks that look like leftovers but document something:

- pseudo-code naming the branches of the code below or beside it — `IfNode`, `MatchAlgorithmCompiler`, and the
  inline `/* if (!blocks && !overrides) */` that names the `else` branch in `OverlappingCheckerImpl2`;
- the Java equivalent of the bytecode an ASM generator emits — the `// bean = new Bean();` family in
  `SpreadsheetResultBeanByteCodeGenerator`;
- an equivalent formula written beside the expression in use — `DecisionTableLookupConvertor`, `TextInfo`;
- code disabled with its reason next to it — `ResultExport` (EPBDS-7848, merged-region validation) — or with an
  author and a date, `IntExpImpl` ("commented by SV 02.06.03 by SV due to domain improvements");
- a sample of the JSON string built below it (`OpenLService`), a `/* package */` visibility marker, and the
  `@author` tags that sit in plain block comments.

## 2. Remove commented-out code left in stylesheets and scripts

3 files, 23 deletions: a disabled `onbeforeunload` guard in the table editor script, and one commented-out declaration in the webstudio stylesheet.

**Evidence.** Every `/* */` block in every `.css` and `.js` file was extracted (543 blocks) and put through the same statement-versus-prose rule. Only these two hits are commented-out code in sources this repository owns; everything else is documentation or a vendored library.

**Bundle handling.** `js/TableEditor.js` is a build input, so the generated bundles were regenerated with the repo's own scripts rather than by hand. `sh compile.js.sh` reproduces both committed bundles byte for byte — verified on the untouched tree before any edit — so `js/tableeditor.all.js` is a plain concatenation and carries the deletion, while `js/tableeditor.min.js` comes out byte-identical because the minifier already strips comments. `webapp/css/common.css` belongs to webstudio and feeds no tableeditor bundle; its line sits inside a live rule and changes no rendering, and ITEST `001-Get-Static-CSS` asserts only the status and content type of `/css/common.css`, never its body.

**Kept deliberately** — the vendored third-party scripts and stylesheets, which carry commented-out code of their own: tableeditor `js/datepicker.js` and `css/datepicker.css` (DatePicker 5.4, CC BY-SA), `js/prototype/prototype-1.7.3.js`, and webstudio `diff2html.js`, `diff2html.css` and `javascript/vendor/**`. Editing any of them forks the upstream copy for the sake of a comment.

## Deferred

Commented-out code in test sources (~30 runs plus one block) is not in this PR at all. Disabled bodies (`ValidatorTest`, `TokenizerParserTest`, `TestIntExpAddArray`) and disabled assertions (`MethodSearchTest`, `PropertyTableTest`, `OpenAPIGroovyScriptGeneratorTest`) can be known-issue markers rather than leftovers, and the `// files = new File[] {...}` line in three test runners is a single-folder debug switch a developer uncomments. Those need a maintainer's call.

Two further shapes were left out on purpose:

- two commented-out alternatives that share their line with live code, in `ColumnDescriptor.loadMultiRowArray` and
  `XlsSheetGridModel.setCellStyle`. Removing either edits a live line, which gives up the deletion-only proof
  above, so they are a separate change type rather than part of this commit;
- the 153 `/* (non-Javadoc) @see ... */` markers beside overriding methods. They are redundant next to
  `@Override`, but they are comment churn rather than dead code, so a 600-line diff should not arrive as a side
  effect of this sweep.

## Also swept and empty, so nothing to review here

- all 62 `ui:param` declarations in the 14 pages that use them, all 442 `xmlns:` prefix declarations in 279 XML/XHTML files, and all 166 class and id selectors in the 22 inline `style` blocks — every one is used, or composed at runtime (the tableeditor table id, for instance, is the JSF client id plus two constant suffixes);
- commented-out markup: all 23 HTML comments in the 54 `.xhtml` and `.html` files are explanations, not disabled markup;
- commented-out TypeScript: none among the 1540 `/* */` blocks in the 562 `studio-ui` sources;
- a property declared twice inside one CSS rule block: none in all 17 stylesheets — every repeated property carries a different value, which is a browser fallback rather than a leftover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)