### PR TITLE
Remove dead code in commented-out blocks

### DIFF
--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/consistencyChecking/DTCheckerImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/consistencyChecking/DTCheckerImpl.java
@@ -111,7 +111,7 @@ public class DTCheckerImpl implements DTChecker {
     private CDecisionTable _dt;
     private final CompletenessChecker _cpChecker = new CompletenessCheckerImpl();
 
-    private final OverlappingChecker _opChecker; // = new OverlappingCheckerImpl();
+    private final OverlappingChecker _opChecker;
 
     private final List<Uncovered> _uncoveredRegions = new ArrayList<>();
 

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/IntExpImpl.java
@@ -129,13 +129,6 @@ public abstract class IntExpImpl extends ExpressionImpl implements IntExp {
 
     @Override
     public void removeRange(int min, int max) throws Failure {
-        /*
-         * commented by SV 02.06.03 by SV due to domain improvements if(min > max) throw new
-         * IllegalArgumentException("removeRange: min > max");
-         *
-         * if(min <= min()) { setMin(max + 1); } else if(max >= max()) { setMax(min - 1); } else // min() < min <= max <
-         * max() { removeRangeInternal(min,max); }
-         */
         removeRangeInternal(min, max); // added by SV 02.06.03 by SV due to
         // domain improvements
     }

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/UndoableIntImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/UndoableIntImpl.java
@@ -11,8 +11,6 @@ import org.openl.ie.tools.ReusableFactory;
 /**
  * A generic implementation of the UndoableInt.
  */
-// public final class UndoableIntImpl extends UndoableOnceImpl implements
-// UndoableInt
 public final class UndoableIntImpl extends UndoableImpl implements UndoableInt {
     /**
      * Undo Class for UndoUndoableInt.

--- a/DEV/org.openl.rules.test/test/org/openl/module/ModuleTest.java
+++ b/DEV/org.openl.rules.test/test/org/openl/module/ModuleTest.java
@@ -307,7 +307,6 @@ class ModuleTest {
         /*
          * This invocation does not work with primitive values, e.g. in arithemtic expressions
          */
-        // Object obj = executeOpenLGetExpression(order, MATH_OPENL);
         // XXX: workaround: have to specify expected return type for arithmetic
         // expressions - not good for BLS engine
         var obj = executeOpenLExprression(order, MATH_OPENL, JavaOpenClass.getOpenClass(Double.class)); // <--
@@ -327,7 +326,6 @@ class ModuleTest {
         /*
          * This invocation does not work with primitive values, e.g. in arithemtic expressions
          */
-        // Object obj = executeOpenLGetExpression(order, MATH_OPENL);
         // XXX: workaround: have to specify expected return type for arithmetic
         // expressions - not good for BLS engine
         var obj = executeOpenLOGNLExprression(order, MATH_OGNL); // <--

--- a/DEV/org.openl.rules.test/test/org/openl/syntax/TokenizerParserTest.java
+++ b/DEV/org.openl.rules.test/test/org/openl/syntax/TokenizerParserTest.java
@@ -27,12 +27,9 @@ class TokenizerParserTest {
         var start = System.currentTimeMillis();
         var test = "a123344 b1233468474 c238746374";
         var n = 1000000;
-        // String delim = ". \n\r{}[]!@#$%^&*()-_+=,.<>/?;:'\"\\|";
         var src = new StringSourceCodeModule(test, null);
-        // TokenizerParser tp = new TokenizerParser(delim);
         for (var i = 0; i < n; ++i) {
             Tokenizer.tokenize(src, " \n\r");
-            // tp.parse(new StringSourceCodeModule(test, null));
         }
         var end = System.currentTimeMillis();
 

--- a/DEV/org.openl.rules/src/org/openl/binding/impl/BindingContext.java
+++ b/DEV/org.openl.rules/src/org/openl/binding/impl/BindingContext.java
@@ -50,12 +50,6 @@ public class BindingContext implements IBindingContext {
 
     private boolean executionMode;
 
-    /*
-     * // NOTE: A temporary implementation of multi-module feature.
-     *
-     * private Set<IOpenClass> imports = new LinkedHashSet<IOpenClass>();
-     */
-
     public BindingContext(IOpenBinder binder, IOpenClass returnType, OpenL openl) {
         this.binder = binder;
         this.returnType = returnType;

--- a/DEV/org.openl.rules/src/org/openl/rules/data/ColumnDescriptor.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/data/ColumnDescriptor.java
@@ -351,7 +351,7 @@ public class ColumnDescriptor {
 
         // get height of table without empty cells at the end
         //
-        var valuesTableHeight = RuleRowHelper.calculateHeight(logicalTable);/* logicalTable.getHeight(); */
+        var valuesTableHeight = RuleRowHelper.calculateHeight(logicalTable);
         var values = new ArrayList<Object>(valuesTableHeight);
 
         for (var i = 0; i < valuesTableHeight; i++) {

--- a/DEV/org.openl.rules/src/org/openl/rules/dt/type/domains/IntRangeDomainAdaptor.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/dt/type/domains/IntRangeDomainAdaptor.java
@@ -12,7 +12,7 @@ public class IntRangeDomainAdaptor implements IDomainAdaptor {
 
     @Override
     public int getIndex(Object value) {
-        return (Integer) value;// - irange.getMin();
+        return (Integer) value;
     }
 
     @Override
@@ -32,7 +32,7 @@ public class IntRangeDomainAdaptor implements IDomainAdaptor {
 
     @Override
     public Object getValue(int index) {
-        return index; // irange.getMin();// + index;
+        return index;
     }
 
     @Override

--- a/DEV/org.openl.rules/src/org/openl/rules/table/xls/XlsSheetGridModel.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/table/xls/XlsSheetGridModel.java
@@ -379,12 +379,7 @@ public class XlsSheetGridModel extends AGrid implements IWritableGrid {
         if (style instanceof XlsCellStyle cellStyle) {
             newPoiStyle = cellStyle.getXlsStyle();
             newPoiStyle.cloneStyleFrom(newPoiStyle);
-        } /*
-         * else if (style instanceof org.openl.rules.table.ui.CellStyle) { styleToClone = poiCell.getCellStyle();
-         * newPoiStyle.cloneStyleFrom(styleToClone);
-         *
-         * setCellStyle(newPoiStyle, style); }
-         */ else {
+        } else {
             newPoiStyle = PoiExcelHelper.createCellStyle(sheet.getWorkbook());
             styleToClone = poiCell.getCellStyle();
             newPoiStyle.cloneStyleFrom(styleToClone);

--- a/DEV/org.openl.rules/src/org/openl/rules/testmethod/export/ResultExport.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/testmethod/export/ResultExport.java
@@ -63,7 +63,6 @@ public abstract class ResultExport extends BaseExport {
                 // Tracking all columns for auto sizing is expensive
                 // sheet.trackAllColumnsForAutoSizing();
                 parameterExport.write(sheet, resultsList, skipEmptyParameters);
-                // autoSizeColumns(sheet);
 
                 // EPBDS-7848 Previously we added regions without validation, so it's better to validate in the end.
                 // But on a big project "Test into file" with validation runs ~2 min 20 sec and without validation

--- a/DEV/org.openl.rules/src/org/openl/util/text/TextInfo.java
+++ b/DEV/org.openl.rules/src/org/openl/util/text/TextInfo.java
@@ -35,7 +35,6 @@ public class TextInfo {
             return idx;
         }
 
-        // return -idx + 1;
         // Zero based lineIdx == InsertionPoint - 1
         return -idx - 1 - 1; // TODO SAM: No test case yet.
     }

--- a/DEV/org.openl.rules/test/org/openl/binding/impl/MethodSearchTest.java
+++ b/DEV/org.openl.rules/test/org/openl/binding/impl/MethodSearchTest.java
@@ -46,11 +46,8 @@ class MethodSearchTest extends AbstractMethodSearchTest {
         assertInvoke("Long", ClassWithGenerics.class, "method2", Byte.class, Long.class);
         assertInvoke("Double", ClassWithGenerics.class, "method2", Double.class, short.class);
 
-        // assertNotFound( ClassWithGenerics.class, "method3", byte[].class, byte[].class);
-
         assertInvoke("M8", ClassWithGenerics.class, "method4", byte[].class);
         assertInvoke("M8", ClassWithGenerics.class, "method4", byte[].class, byte[].class);
-        // assertNotFound( ClassWithGenerics.class, "method4", byte[].class, byte[].class, byte[].class);
         assertInvoke("M8", ClassWithGenerics.class, "method4", byte[].class, byte.class, byte.class);
 
         assertInvoke("M9", ClassWithGenerics.class, "method5", byte[].class);
@@ -98,14 +95,10 @@ class MethodSearchTest extends AbstractMethodSearchTest {
         assertInvoke("M17-2", ForthClassWithMethods.class, "method8", String.class, String.class);
 
         assertInvoke("M21", ForthClassWithMethods.class, "method7");
-
-        // assertAmbiguous(ForthClassWithMethods.class, "method7", String.class);
         assertInvoke("M19", ForthClassWithMethods.class, "method7", String.class);
 
         assertInvoke("M20", ForthClassWithMethods.class, "method7", String.class, String.class);
         assertAmbiguous(ForthClassWithMethods.class, "method7", null, null);
-
-        // assertAmbiguous(ForthClassWithMethods.class, "method7", String.class, String.class, String.class);
         assertInvoke("M19", ForthClassWithMethods.class, "method7", String.class, String.class, String.class);
 
         assertInvoke("M16", ForthClassWithMethods.class, "method7", Integer.class);

--- a/DEV/org.openl.rules/test/org/openl/excel/parser/ParserTest.java
+++ b/DEV/org.openl.rules/test/org/openl/excel/parser/ParserTest.java
@@ -216,10 +216,6 @@ class ParserTest {
 
     @Test
     void testLiteral() throws OpenLConfigurationException {
-        // we should remove suffix the next line produces NumberFormatException
-        // Assert.assertEquals(new Long(5), Long.decode("5L"));
-
-        // _testLiteral("-5L", "-5L", "literal.integer");
         _testLiteral("0xff", "0xff", "literal.integer");
         _testLiteral("5L", "5L", "literal.integer");
         _testLiteral("\"ab\\n\"", "\"ab\\n\"", "literal.string");

--- a/DEV/org.openl.rules/test/org/openl/rules/binding/NumbersEQTest.java
+++ b/DEV/org.openl.rules/test/org/openl/rules/binding/NumbersEQTest.java
@@ -1,7 +1,5 @@
 package org.openl.rules.binding;
 
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeAll;

--- a/DEV/org.openl.rules/test/org/openl/rules/property/PropertiesTableInExecutionModeTest.java
+++ b/DEV/org.openl.rules/test/org/openl/rules/property/PropertiesTableInExecutionModeTest.java
@@ -66,9 +66,6 @@ class PropertiesTableInExecutionModeTest {
             assertEquals(RegionsEnum.NCSA.name(), ((RegionsEnum[]) categoryProperties.get("region"))[0].name());
 
             Map<String, Object> defaultProperties = tableProperties.getDefaultProperties();
-            // assertTrue(defaultProperties.size() == 5);
-            // assertEquals("US",(String) defaultProperties.get("country"));
-
             assertTrue((Boolean) defaultProperties.get("active"));
             assertFalse((Boolean) defaultProperties.get("failOnMiss"));
         } else {

--- a/DEV/org.openl.rules/test/org/openl/rules/property/PropertyTableTest.java
+++ b/DEV/org.openl.rules/test/org/openl/rules/property/PropertyTableTest.java
@@ -49,9 +49,6 @@ class PropertyTableTest extends BaseOpenlBuilderHelper {
         assertEquals(RegionsEnum.NCSA, ((RegionsEnum[]) categoryProperties.get("region"))[0]);
 
         Map<String, Object> defaultProperties = tableProperties.getDefaultProperties();
-        // assertTrue(defaultProperties.size() == 5);
-        // assertEquals("US",(String) defaultProperties.get("country"));
-
         assertTrue((Boolean) defaultProperties.get("active"));
         assertFalse((Boolean) defaultProperties.get("failOnMiss"));
     }

--- a/DEV/org.openl.rules/test/org/openl/rules/validator/dt/ValidatorTest.java
+++ b/DEV/org.openl.rules/test/org/openl/rules/validator/dt/ValidatorTest.java
@@ -40,22 +40,6 @@ class ValidatorTest extends BaseOpenlBuilderHelper {
         var tableName = "Rules String validationOK(TestValidationEnum1 value1, TestValidationEnum2 value2)";
         var domains = new HashMap<String, IDomainAdaptor>();
 
-        // EnumDomain<TestValidationEnum1> enumDomain1 = new
-        // EnumDomain<TestValidationEnum1>(new
-        // TestValidationEnum1[]{TestValidationEnum1.V1,
-        // TestValidationEnum1.V2});
-        // EnumDomainAdaptor enumDomainAdaptor1 = new
-        // EnumDomainAdaptor(enumDomain1);
-        // domains.put("value1", enumDomainAdaptor1);
-        //
-        // EnumDomain<TestValidationEnum2> enumDomain2 = new
-        // EnumDomain<TestValidationEnum2>(new
-        // TestValidationEnum2[]{TestValidationEnum2.V1,
-        // TestValidationEnum2.V2});
-        // EnumDomainAdaptor enumDomainAdaptor2 = new
-        // EnumDomainAdaptor(enumDomain2);
-        // domains.put("value2", enumDomainAdaptor2);
-
         var dtValidResult = testTable(tableName, domains);
         assertFalse(dtValidResult.hasProblems());
     }
@@ -98,14 +82,10 @@ class ValidatorTest extends BaseOpenlBuilderHelper {
 
             var dt = (IDecisionTable) resultTsn.getMember();
             try {
-                // System.out.println("Validating <" + tableName+ ">");
                 result = DecisionTableValidator.validateTable(dt, domains, getCompiledOpenClass().getOpenClass());
 
                 if (result.hasProblems()) {
                     resultTsn.setValidationResult(result);
-                    // System.out.println("There are problems in table!!\n");
-                } else {
-                    // System.out.println("NO PROBLEMS IN TABLE!!!!\n");
                 }
             } catch (Exception t) {
                 fail();

--- a/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryTest.java
+++ b/STUDIO/org.openl.rules.repository.git/test/org/openl/rules/repository/git/GitRepositoryTest.java
@@ -217,10 +217,6 @@ class GitRepositoryTest {
         assertContains(files, "rules/project1/file2");
         assertContains(files, "rules/project1/folder/file3");
 
-        // Each file has last modified project version, to performance improve
-        // FileData file1Rev3 = find(files, "rules/project1/file1");
-        // assertEquals("Rules_2", file1Rev3.getVersion()); // The file has not been modified in second commit
-
         var file2Rev3 = find(files, "rules/project1/file2");
         assertEquals("Rules_3", file2Rev3.getVersion());
         assertEquals("User 2", file2Rev3.getAuthor().getName());

--- a/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/ui/tree/WorksheetTreeNodeBuilder.java
+++ b/STUDIO/org.openl.rules.webstudio/src/org/openl/rules/ui/tree/WorksheetTreeNodeBuilder.java
@@ -46,7 +46,7 @@ public class WorksheetTreeNodeBuilder extends BaseTableTreeNodeBuilder {
      */
     @Override
     public Object makeObject(TableSyntaxNode tableSyntaxNode) {
-        return tableSyntaxNode.getXlsSheetSourceCodeModule();//getModule();
+        return tableSyntaxNode.getXlsSheetSourceCodeModule();
     }
 
     @Override

--- a/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/ui/DatatypeChangeTest.java
+++ b/STUDIO/org.openl.rules.webstudio/test/org/openl/rules/ui/DatatypeChangeTest.java
@@ -34,8 +34,6 @@ class DatatypeChangeTest extends AbstractWorkbookGeneratingTest {
 
         WebStudio ws = mock(WebStudio.class);
 
-        // EhCacheUtils.createCache();
-
         pm = new ProjectModel(ws);
         for (Module module : modules) {
             if (module.getName().equals("ExpenseModule")) {

--- a/Util/openl-openapi-parser/test/org/openl/rules/openapi/impl/OpenAPIGroovyScriptGeneratorTest.java
+++ b/Util/openl-openapi-parser/test/org/openl/rules/openapi/impl/OpenAPIGroovyScriptGeneratorTest.java
@@ -208,7 +208,6 @@ class OpenAPIGroovyScriptGeneratorTest {
         assertArrayEquals(new String[]{"application/json"}, method1.getAnnotation(Consumes.class).value());
         assertArrayEquals(new String[]{"application/json"}, method1.getAnnotation(Produces.class).value());
         assertEquals("Policy", method1.getAnnotation(RulesType.class).value());
-        // assertTrue(commonClasses.contains(method1.getAnnotation(ServiceExtraMethod.class).value()));
 
         assertEquals(2, method1.getParameters()[0].getAnnotations().length);
         assertEquals("Policy", method1.getParameters()[0].getAnnotation(RulesType.class).value());
@@ -444,7 +443,6 @@ class OpenAPIGroovyScriptGeneratorTest {
         assertEquals(2, method2.getParameters()[0].getAnnotations().length);
         assertEquals("Policy", method2.getParameters()[0].getAnnotation(RulesType.class).value());
         assertEquals("policy", method2.getParameters()[0].getAnnotation(Name.class).value());
-        // assertTrue(commonClasses.contains(method2.getAnnotation(ServiceExtraMethod.class).value()));
     }
 
     @Test


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Daily dead-code sweep, continuing after #2088 merged. Each commit carries exactly one change type across the whole repository, so a reviewer checks the rule once per commit. This commit deletes comments only: no statement, declaration or resource changes, so the compiled classes are the same as on `main` except for line numbers.

**Commits:** 1 · **Diff:** 21 files changed, 6 insertions(+), 80 deletions(-)

## Remove commented-out code left behind by earlier rewrites

- **Removed:** 33 comment blocks in 21 files that contain only Java statements: disabled assertions in tests (`MethodSearchTest`, `PropertyTableTest`, `PropertiesTableInExecutionModeTest`, `ParserTest`, `OpenAPIGroovyScriptGeneratorTest`, `GitRepositoryTest`), an unused enum-domain setup and three `System.out.println` calls in `ValidatorTest`, the old `removeRange` body in `IntExpImpl`, an old `else if` branch in `XlsSheetGridModel`, a former field in `BindingContext`, a superseded class declaration in `UndoableIntImpl`, a duplicated import in `NumbersEQTest`, and trailing fragments such as `// = new OverlappingCheckerImpl();` (`DTCheckerImpl`), `/* logicalTable.getHeight(); */` (`ColumnDescriptor`), `//getModule();` (`WorksheetTreeNodeBuilder`), `// - irange.getMin();` (`IntRangeDomainAdaptor`), `// return -idx + 1;` (`TextInfo`), `// autoSizeColumns(sheet);` (`ResultExport`), `// EhCacheUtils.createCache();` (`DatatypeChangeTest`; the class no longer exists), the unused `TokenizerParser` lines in `TokenizerParserTest` and the `executeOpenLGetExpression` lines in `ModuleTest`. The 6 inserted lines are the shortened statements (`} else {`, `return index;`, ...). In `ValidatorTest` the removal left an `else` block with no content; that empty block was dropped with it.
- **Evidence:** SonarCloud rule `java:S125` ("This block of commented-out lines of code should be removed") lists 71 open blocks on `main`; each was read in full, since the rule reports only the first line of a block. 32 of them are statements with no explanation, or whose only note says the code was disabled (`commented by SV 02.06.03`), and are removed here together with one unflagged sibling line in `TokenizerParserTest`. The other 39 stay: 35 are prose that reads like code (pseudo-code explaining a branch in `IfNode`, bytecode-generator annotations in `SpreadsheetResultBeanByteCodeGenerator` and `EqualsWriter`, `<code>` examples in `CastFactory`, path and JSON templates in `Migrator` and `OpenLService`, `{@link}` notes in `ColumnDescriptor` and `DatatypeOpenClass`), TODO/FIXME/XXX notes (`RuleRowHelper`, `GridTool`, `AlgorithmSubroutineMethod`, `PathCheckedRepository`, `HeadersWithSpacesTest`), or decisions recorded with their reason (`SecureRepository.check`, `XlsModuleOpenClass.addDependencyTypes`, `ResultExport` merged-region validation); 4 are developer toggles that a maintainer uncomments on purpose (the `files = new File[]{...}` single-folder selectors in `RulesInFolderTestRunner`, `OpenAPIGenerationTest` and `OpenAPIProjectCreatorTest`, and the bulk OpenAPI fixture rewrite in ITEST `HttpClient`) and are left for a human decision.
- **Verified:** `mvn clean install -Dquick -DnoPerf -T1C` over the whole reactor (86 modules) with this change applied on top of the #2088 head, green; `mvn validate -N` clean. The commit was then cherry-picked onto the current `main` without conflicts; because the diff removes comments only, the GitHub Actions build on this PR is the compile check for the new base.
- **Kept or deferred:** the 39 blocks above.

## Zero-yield sweeps this run

- The 3 non-workbook files under module `test/` folders (`webstudio/test/rules/classes/test.jar`, `locking/beans.jar`, `locking/rules.xml`) are opened by path in `WizardUtilsTest` or copied as a folder by `ProjectDeleteTest`.
- JSF registrations (both `faces-config.xml` files, `html.taglib.xml`, `tableeditor.taglib.xml`), the `web.xml` filters and listeners, every Maven profile (property-, `env.CI`- or workflow-activated; `owasp` is a manual tool profile) and every root `pluginManagement` entry (lifecycle, packaging or workflow-invoked) are alive. The `tableViewer` tag and its `UITableViewer` component and renderer registration have no page usage, but the tableeditor module is a published artifact, so they are left for a human decision.
- The other SonarCloud unused-code findings on `main` (S1068, S1481, S1854, S1144) are reflection-bound test fixtures, the already-deferred taglib and setter-fed fields, `var ignored = executor.submit(...)` assignments that silence Error Prone's `FutureReturnValueIgnored`, and a method reference the rule does not see.

## Verification note

The build ran with `LANG=C.UTF-8` and with `commit.gpgsign` unset in the sandbox: the container sets no locale (which breaks one archive test on a non-ASCII fixture name) and forces ssh commit signing that JGit cannot perform. Neither relates to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVdi52mpHz3PMHmQbQCU3v)_