### PR TITLE
Gate pull requests on cross-repository OpenL Tests

### DIFF
--- a/.github/workflows/build-quick.yml
+++ b/.github/workflows/build-quick.yml
@@ -40,6 +40,9 @@ on:
       - 'Docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -56,6 +59,27 @@ jobs:
           git config --global core.autocrlf false
 
       - uses: actions/checkout@v7
+
+      # workflow_run.pull_requests is empty for pull requests from forks. Pass the immutable
+      # source identity as an artifact so the privileged follow-up workflow never has to infer it.
+      - name: Prepare OpenL Tests metadata
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p e2e-metadata
+          printf '%s\n' "${HEAD_SHA}" > e2e-metadata/head-sha
+          printf '%s\n' "${PR_NUMBER}" > e2e-metadata/pr-number
+
+      - name: Share OpenL Tests metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: openl-e2e-metadata
+          path: e2e-metadata
+          if-no-files-found: error
+          retention-days: 3
 
       - name: Setup Java 25
         uses: actions/setup-java@v6
@@ -75,6 +99,21 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B "-Dstyle.color=always" -T1C install -DskipTests
+
+      # The follow-up workflow runs with base-repository credentials, so this artifact contains
+      # only inert image content. It deliberately excludes the pull request's Dockerfile.
+      - name: Share OpenL Tests image context
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: openl-e2e-image-context
+          path: |
+            STUDIO/org.openl.rules.webstudio/target/webapp
+            WSFrontend/org.openl.rules.ruleservice.ws.all/target/webapp
+            Util/openl-rules-opentelemetry/target/openl-rules-opentelemetry.jar
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 3
 
       - name: Create DEMO package
         run: |
@@ -360,6 +399,10 @@ jobs:
     name: Sonar analysis
 
     needs: [ tests, itest ]
+
+    permissions:
+      contents: read
+      pull-requests: read
 
     # Runs only when every previous job succeeded, and never for dependabot
     if: success() && github.actor != 'dependabot[bot]'

--- a/.github/workflows/dispatch-openl-tests.yml
+++ b/.github/workflows/dispatch-openl-tests.yml
@@ -1,0 +1,178 @@
+name: Dispatch OpenL Tests
+
+on:
+  workflow_run:
+    workflows:
+      - Quick Build
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  packages: write
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: >-
+    dispatch-openl-tests-${{ github.event.workflow_run.head_repository.id }}-${{
+      github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Publish images and dispatch tests
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      BUILD_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+
+    steps:
+      # Use only the trusted Dockerfile from the default branch. The pull request artifact supplies
+      # the compiled applications, but no pull request code executes with this workflow's credentials.
+      - name: Checkout trusted image definition
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download pull request metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: openl-e2e-metadata
+          path: e2e-metadata
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate pull request metadata
+        id: metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(tr -d '\r\n' < e2e-metadata/pr-number)
+          SOURCE_SHA=$(tr -d '\r\n' < e2e-metadata/head-sha)
+          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]
+          [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ ]]
+
+          PR=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+          test "$(jq -r '.base.repo.full_name' <<< "${PR}")" = "${GITHUB_REPOSITORY}"
+          test "$(jq -r '.head.sha' <<< "${PR}")" = "${SOURCE_SHA}"
+
+          echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=${SOURCE_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "image_tag=pr-${PR_NUMBER}-${SOURCE_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Report failed Quick Build
+        if: github.event.workflow_run.conclusion != 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.metadata.outputs.head_sha }}
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${SOURCE_SHA}" \
+            -f state=failure \
+            -f context=openl-tests \
+            -f description='Quick Build failed before OpenL Tests could start' \
+            -f target_url="${BUILD_RUN_URL}"
+
+      - name: Report OpenL Tests pending
+        if: github.event.workflow_run.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.metadata.outputs.head_sha }}
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${SOURCE_SHA}" \
+            -f state=pending \
+            -f context=openl-tests \
+            -f description='Publishing pull request images and starting OpenL Tests' \
+            -f target_url="${BUILD_RUN_URL}"
+
+      - name: Download OpenL Tests image context
+        if: github.event.workflow_run.conclusion == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: openl-e2e-image-context
+          path: e2e-image-context
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Build and publish pull request images
+        if: github.event.workflow_run.conclusion == 'success'
+        env:
+          IMAGE_TAG: ${{ steps.metadata.outputs.image_tag }}
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          echo "${{ github.token }}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+          created="org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          revision="org.opencontainers.image.revision=${{ steps.metadata.outputs.head_sha }}"
+
+          docker build \
+            --build-arg APP=STUDIO/org.openl.rules.webstudio/target/webapp \
+            --file "${GITHUB_WORKSPACE}/Dockerfile" \
+            --label "${created}" \
+            --label "${revision}" \
+            --label 'org.opencontainers.image.title=OpenL Studio' \
+            --tag "${REGISTRY}/webstudio:${IMAGE_TAG}" \
+            e2e-image-context
+          docker push "${REGISTRY}/webstudio:${IMAGE_TAG}"
+
+          docker build \
+            --build-arg APP=WSFrontend/org.openl.rules.ruleservice.ws.all/target/webapp \
+            --file "${GITHUB_WORKSPACE}/Dockerfile" \
+            --label "${created}" \
+            --label "${revision}" \
+            --label 'org.opencontainers.image.title=OpenL Rule Services (All)' \
+            --tag "${REGISTRY}/ws:${IMAGE_TAG}-all" \
+            e2e-image-context
+          docker push "${REGISTRY}/ws:${IMAGE_TAG}-all"
+
+      - name: Create token for OpenL Tests
+        if: github.event.workflow_run.conclusion == 'success'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.E2E_APP_ID }}
+          private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: openl-tests
+          permission-actions: write
+
+      - name: Dispatch OpenL Tests
+        if: github.event.workflow_run.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          IMAGE_TAG: ${{ steps.metadata.outputs.image_tag }}
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+          SOURCE_SHA: ${{ steps.metadata.outputs.head_sha }}
+        run: |
+          jq -n \
+            --arg application_version "${IMAGE_TAG}" \
+            --arg pr_number "${PR_NUMBER}" \
+            --arg source_sha "${SOURCE_SHA}" \
+            '{
+              ref: "main",
+              inputs: {
+                application_version: $application_version,
+                tests_branch: "main",
+                pr_number: $pr_number,
+                source_sha: $source_sha
+              }
+            }' | gh api --method POST \
+              "repos/${GITHUB_REPOSITORY_OWNER}/openl-tests/actions/workflows/openl-tests.yml/dispatches" \
+              --input -
+
+      - name: Report orchestration failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.metadata.outputs.head_sha || github.event.workflow_run.head_sha }}
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${SOURCE_SHA}" \
+            -f state=failure \
+            -f context=openl-tests \
+            -f description='OpenL Tests could not be started' \
+            -f target_url="${BUILD_RUN_URL}"

--- a/.github/workflows/skip-openl-tests-for-docs.yml
+++ b/.github/workflows/skip-openl-tests-for-docs.yml
@@ -1,0 +1,55 @@
+name: Skip OpenL Tests for documentation
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: skip-openl-tests-docs-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    name: Classify documentation-only change
+    runs-on: ubuntu-latest
+
+    steps:
+      # pull_request_target gives fork pull requests a base-repository token. Do not check out or
+      # execute pull request code in this workflow; only inspect GitHub's changed-file metadata.
+      - name: Report OpenL Tests skipped for documentation-only changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_FILES_URL: ${{ github.event.pull_request.html_url }}/files
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
+
+          FILES_FILE="${RUNNER_TEMP}/pull-request-files.json"
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" > "${FILES_FILE}"
+
+          TOTAL=$(jq '[.[][]] | length' "${FILES_FILE}")
+          NON_DOCS=$(jq '[.[][] | select(
+            (.filename | startswith("Docs/") | not) or
+            ((.previous_filename // "") != "" and (.previous_filename | startswith("Docs/") | not))
+          )] | length' "${FILES_FILE}")
+
+          if [ "${TOTAL}" -eq 0 ] || [ "${NON_DOCS}" -ne 0 ]; then
+            echo "The pull request is not documentation-only; OpenL Tests will run normally."
+            exit 0
+          fi
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context=openl-tests \
+            -f description='OpenL Tests skipped for documentation-only changes' \
+            -f target_url="${PR_FILES_URL}"

--- a/Docs/architecture/cross-repository-e2e-gating.md
+++ b/Docs/architecture/cross-repository-e2e-gating.md
@@ -1,0 +1,104 @@
+# Cross-Repository End-to-End Gating
+
+OpenL Tablets pull requests are gated by the end-to-end suite in the separate
+[`openl-tablets/openl-tests`](https://github.com/openl-tablets/openl-tests) repository. GitHub commit statuses join
+the two workflows without making either workflow poll the other.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant PR as OpenL Tablets pull request
+    participant C as Docs-only classifier
+    participant QB as Quick Build
+    participant D as Dispatch OpenL Tests
+    participant E2E as openl-tests
+    participant P as GitHub Pages
+
+    PR->>C: Inspect changed-file metadata
+    alt Every path is under Docs/
+        C->>PR: openl-tests = success (skipped)
+    else Code or mixed changes
+        PR->>QB: Build head SHA
+        QB->>QB: Upload PR metadata and image content
+        QB-->>D: workflow_run completed
+        D->>PR: openl-tests = pending
+        D->>D: Publish SHA-tagged images to GHCR
+        D->>E2E: workflow_dispatch
+        E2E->>P: Publish pr-number report
+        E2E->>PR: openl-tests = success or failure
+    end
+```
+
+`Quick Build` uploads the pull request number and head SHA separately from the compiled OpenL Studio and OpenL
+Rule Services web applications. `Dispatch OpenL Tests` runs from the default branch in the base repository, which
+gives fork pull requests access to the required repository credentials without exposing them to pull request code.
+It validates the artifact against the current pull request, builds images with the trusted default-branch
+`Dockerfile`, and publishes these tags:
+
+- `ghcr.io/openl-tablets/webstudio:pr-<number>-<head SHA>`
+- `ghcr.io/openl-tablets/ws:pr-<number>-<head SHA>-all`
+
+The test workflow publishes pull request reports at
+`https://openl-tablets.github.io/openl-tests/pr-<number>/`. A new head commit cancels the older test run for that
+pull request and replaces its report. Standalone `openl-tests` runs keep their existing `runs/<run id>/` paths and
+retention policy.
+
+Quick Build ignores pull requests whose changed files are all under `Docs/`. The `Skip OpenL Tests for
+documentation` workflow handles those pull requests and posts `openl-tests` as successful without running the build
+or suite. It uses `pull_request_target` so the base-repository status token is available for forks, but it only reads
+GitHub's changed-file metadata and never checks out or executes pull request code. Renames are documentation-only
+only when both the old and new paths are under `Docs/`; mixed documentation and code changes run the normal gate.
+
+If Quick Build or the dispatch chain fails before the suite starts, the dispatch workflow reports `failure` instead
+of leaving a permanent pending status.
+
+## One-Time GitHub Setup
+
+Create one GitHub App owned by the `openl-tablets` organization.
+
+- Grant repository permission **Actions: Read and write** so the OpenL Tablets workflow can dispatch
+  `openl-tests`.
+- Grant repository permission **Commit statuses: Read and write** so `openl-tests` can update an OpenL Tablets
+  commit.
+- Install the app on both `openl-tablets/openl-tablets` and `openl-tablets/openl-tests`.
+- Create an app private key. Store its complete PEM value as the organization Actions secret
+  `E2E_APP_PRIVATE_KEY`, with access to both repositories.
+- Store the numeric app ID as the organization Actions variable `E2E_APP_ID`, with access to both repositories.
+
+Each workflow mints a token for only the destination repository and permission it needs. The OpenL Tablets
+workflow uses its own `GITHUB_TOKEN` for the same-repository pending or orchestration-failure status and to publish
+the pull request images to GHCR.
+
+In the OpenL Tablets repository settings:
+
+- Enable **Allow auto-merge** under general pull request settings.
+- Add the exact status context `openl-tests` to the required status checks in the ruleset or branch protection rule
+  for every protected merge target.
+- Confirm that the repository's Actions workflows can write the `webstudio` and `ws` organization container
+  packages. Grant repository Actions access on an existing package if that package does not inherit access.
+
+The `workflow_dispatch` trigger in `openl-tests.yml` must be present on the `openl-tests` default branch before the
+OpenL Tablets dispatch workflow is enabled. Merge the `openl-tests` change first, then the OpenL Tablets change.
+
+## End-to-End Verification
+
+1. Open an OpenL Tablets pull request from a repository branch. Confirm Quick Build uploads
+   `openl-e2e-metadata` and `openl-e2e-image-context`.
+2. Confirm `Dispatch OpenL Tests` posts a pending `openl-tests` status on the pull request head SHA, publishes both
+   SHA-tagged images, and starts `OpenL Tests` in the other repository.
+3. Confirm the test run publishes `pr-<number>/`, its final status links to that report, and a passing run changes
+   `openl-tests` to success without a manual update.
+4. Repeat from a fork. Confirm the dispatch succeeds even though the pull request workflow itself cannot read the
+   app credentials.
+5. Enable auto-merge on a throwaway pull request, push a temporary change that deterministically violates an E2E
+   assertion, and leave the run to finish. Confirm `openl-tests` is failure and the pull request remains unmerged.
+   Revert that temporary change in a new commit and push again. Confirm the old E2E run is cancelled, the status on
+   the new head SHA becomes success, and auto-merge completes without human intervention.
+6. Open a documentation-only pull request. Confirm Quick Build and the E2E suite do not run, and `openl-tests`
+   reports success with the description `OpenL Tests skipped for documentation-only changes`.
+7. Add a file outside `Docs/` to the same pull request. Confirm the skip workflow does not report success on the new
+   head SHA and the normal Quick Build and E2E chain runs.
+
+For an infrastructure failure before a report can be built, the failure status links to the responsible workflow
+run. Test failures link to the published per-pull-request report.


### PR DESCRIPTION
## Summary

- pass PR metadata and compiled image content from Quick Build to a secret-safe `workflow_run`
- publish SHA-specific OpenL Studio and Rule Services images, then dispatch `openl-tests`
- post a terminal failure when orchestration cannot start
- mark `openl-tests` successful without running builds for documentation-only PRs, including forks
- document GitHub App, auto-merge, branch protection, and end-to-end verification setup
- use named major-version tags for external actions

## Verification

- `actionlint .github/workflows/build-quick.yml .github/workflows/dispatch-openl-tests.yml .github/workflows/skip-openl-tests-for-docs.yml`
- documentation-only, mixed, and renamed-file classifier fixtures evaluated with `jq`
- `mvn validate -N`

## Dependency

Merge the companion [`openl-tablets/openl-tests` branch](https://github.com/openl-tablets/openl-tests/compare/main...codex/cross-repo-pr-gating?expand=1) first so `workflow_dispatch` is present on that repository default branch before this workflow is enabled.