### PR TITLE
Remove dead code in internal engine packages

### DIFF
--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainImplWithHoles.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/DomainImplWithHoles.java
@@ -202,8 +202,4 @@ public final class DomainImplWithHoles extends DomainImpl {
         return _values.toString();
     }
 
-    FastVector values() {
-        return _values;
-    }
-
 } // end of DomainImplWithHoles

--- a/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ExpressionImpl.java
+++ b/DEV/org.openl.rules.constrainer/src/org/openl/ie/constrainer/impl/ExpressionImpl.java
@@ -31,14 +31,6 @@ public abstract class ExpressionImpl extends SubjectImpl implements Expression {
 
     protected static final Class[] ARGS_IntBoolExp2 = {IntBoolExp.class, IntBoolExp.class};
 
-    protected static Expression getExpression(Constrainer c, Class clazz, Object[] args) {
-        return c.expressionFactory().getExpression(clazz, args);
-    }
-
-    protected static Expression getExpression(Constrainer c, Class clazz, Object[] args, Class[] types) {
-        return c.expressionFactory().getExpression(clazz, args, types);
-    }
-
     public ExpressionImpl(Constrainer constrainer, String name) {
         super(constrainer, name);
     }

--- a/DEV/org.openl.rules/src/org/openl/rules/dt/algorithm/DependentParametersOptimizedAlgorithm.java
+++ b/DEV/org.openl.rules/src/org/openl/rules/dt/algorithm/DependentParametersOptimizedAlgorithm.java
@@ -69,12 +69,6 @@ import org.openl.types.impl.ParameterDeclaration;
  */
 class DependentParametersOptimizedAlgorithm {
 
-    static IConditionEvaluator makeEvaluator(ICondition condition,
-                                             IMethodSignature signature,
-                                             IBindingContext bindingContext) {
-        return makeEvaluator(condition, signature, bindingContext, new ICondition[]{condition});
-    }
-
     /**
      * Builds an evaluator for the condition, looking the column parameters up in every column of the table.
      */


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Daily dead-code sweep, continuing after #2088 and #2089 merged. Each commit carries exactly one change type across the whole repository, so a reviewer checks the rule once per commit. Only code in internal (`.impl.`) packages and package-private members is touched; nothing public is removed.

**Commits:** 1 · **Diff:** 3 files changed, 0 insertions(+), 18 deletions(-)

## Remove methods no caller reaches in internal engine packages

- **Removed:** the package-private three-argument `DependentParametersOptimizedAlgorithm.makeEvaluator(ICondition, IMethodSignature, IBindingContext)` in `org.openl.rules.dt.algorithm` (the four-argument overload it forwarded to stays and is the one `DecisionTableAlgorithmBuilder` calls); the two protected static helpers `ExpressionImpl.getExpression(Constrainer, Class, Object[])` and `getExpression(Constrainer, Class, Object[], Class[])` in `org.openl.ie.constrainer.impl` (the protected final instance overloads stay: `getIntBoolExp` and `getIntExp` call them, and `IntBoolExpConst` and `IntExpArray` call the factory directly); the package-private accessor `DomainImplWithHoles.values()` in the same package (the `_values` field stays, every other method of the class reads it).
- **Evidence:** every class file of the whole reactor (5155 classes under `target/classes` and `target/test-classes`, ITEST and `openl-maven-plugin` included) was read with ASM and every method reference (invoke instructions, method handles, lambda bootstrap arguments) was collected; a method is a candidate when no reference anywhere carries its name and descriptor, it is not public, not annotated, and overrides nothing visible in the scan or in the JDK. The scan reported 32 candidates; the other 28 are alive by a mechanism bytecode cannot show: JAXB `beforeMarshal`/`afterUnmarshal` callbacks in `org.openl.rules.project.model`, JUnit `@MethodSource` providers named in annotation values, test fixtures asserted by name (`epbds6830/BeanA`, `AOpenClassTest.C`), generic abstract methods called through a covariant override (`InputStatistics.getAvgX/getAvgY`), the two protected abstract methods already recorded for a human decision (`ADtColumnsDefinitionTableBoundNode.isReturns`, `AbstractOpenlTableExporter.getExcelSheetName`), JavaCC-generated members of `BExGrammarTokenManager`/`SimpleCharStream` (generated sources are never edited), `ExpressionFactoryImpl.findExpression`, which the compiler drops because the cache toggle `_getFromCache` is a constant `false`, and ITEST `HttpData.writeBodyTo`, a documented fixture-capture toggle. Each removal was confirmed with `grep -rIF <name>` over every text file outside `target/` and `node_modules/`: `makeEvaluator` with three arguments is called only on `DecisionTableOptimizedAlgorithm`, the static `getExpression(Constrainer, …)` forms appear nowhere, and no `.values()` call resolves to `DomainImplWithHoles`. A repo-wide PMD 7.27 pass (`UnusedPrivateMethod`, `UnusedPrivateField`, `UnusedLocalVariable`, `UnusedAssignment`, `UnusedFormalParameter`, 46 hits) and an identifier-frequency index over all tracked files found nothing else deletable; their hits are catalogued false positives (Lombok accessors, method references, publication before a callback, try-with-resources variables) or public-API members left for a human decision.
- **Verified:** `mvn -o test -Dquick -DnoPerf -pl DEV/org.openl.rules.constrainer,DEV/org.openl.rules,DEV/org.openl.rules.test`, green; then `mvn -o clean install -Dquick -DnoPerf -T1C` over the whole reactor (86 modules), green; `mvn validate -N` clean.
- **Kept or deferred:** `ExpressionFactoryImpl.findExpression` (compiled out by the constant `_getFromCache = false`; a cache switch, so a maintainer decision); `DecisionTableBuilder.methodName` with its public `setMethodName` and `SimpleGroup.description` with its public setter and constructor parameter (write-only, but public API); the second `serviceDescriptionInProcess` write in `ServiceManagerImpl.deploy` (a no-op only if `createService` cannot re-enter `deploy`); the 18 write-only `ValueExpression` fields of `TableEditorTag`/`TableViewerTag` (taglib attribute surface of a published artifact); the `status` component of the `MergeResult` record, ignored by its compact constructor (public record signature).

## Zero-yield sweeps this run

- Every resource file under a `resources/` directory outside ITEST, `test-resources/**` and the archetypes (45 files whose base name appears in no other file) is alive by convention: Flyway `db/flyway/**` migrations, `spring.factories`, `META-INF/openl/extension-*.xml`, `archetype-metadata.xml`, `META-INF/cxf/org.apache.cxf.Logger`, the OpenTelemetry `META-INF/io/opentelemetry/**` descriptor, `openl-db-repository-<database>.properties` (composed at runtime) and webstudio `logging.properties` (read by Tomcat JULI from `WEB-INF/classes`).
- Error Prone over the whole build: `UnusedMethod`/`UnusedVariable` fire only on the reflection fixtures `epbds6830/BeanA.getAB` and `JsonUtilsTest.BindingClasses`/`KeyClass`.

## Verification note

The builds ran with `LANG=C.UTF-8` and with `commit.gpgsign` unset in the sandbox: the container sets no locale (which breaks one archive test on a non-ASCII fixture name) and forces ssh commit signing that JGit cannot perform. Neither relates to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUmTTjZSbQpakE16Cr23Ke)_