### PR TITLE
Remove a dead message key in OpenL Studio

### DIFF
--- a/STUDIO/org.openl.rules.webstudio/resources/ValidationMessages.properties
+++ b/STUDIO/org.openl.rules.webstudio/resources/ValidationMessages.properties
@@ -165,7 +165,6 @@ openl.error.409.project.merge.same.branches.message = The project branch is equa
 openl.error.409.project.merge.branch.not.found.message = The branch ''{0}'' is not found in the repository.
 openl.error.409.project.merge.invalid.state.message = Cannot merge because the project is not in a valid state for merging.
 openl.error.409.project.merge.branch.locked.message = Cannot merge into the branch ''{0}'' because the project is locked on that branch.
-openl.error.409.project.merge.branch.protected.message = Cannot merge into the branch ''{0}'' because it is protected.
 openl.error.409.protected.branch.bypass.required = The branch ''{0}'' is protected. You may bypass the protection only by confirming a destructive merge.
 openl.error.409.project.branch.merge.not.mergeable.message = Cannot merge because there are no changes between the source and target branches.
 openl.error.409.project.unresolved.merge.conflicts.message = Project has unresolved merge conflicts. Please resolve them first or abort the merge.


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Daily dead-code sweep. Each commit carries exactly one change type across the whole repository, so a reviewer checks the rule once per commit. This pull request carries the single finding that survived proof in the message-bundle pass over `STUDIO/org.openl.rules.webstudio`.

**Commits:** 1 · **Diff:** 1 file changed, 1 deletion(-)

## Drop the protected-branch merge message no endpoint raises any more

- **Removed:** the key `openl.error.409.project.merge.branch.protected.message` from `STUDIO/org.openl.rules.webstudio/resources/ValidationMessages.properties`.
- **Evidence:** the bundle is read by the `validationMessageSource` bean (`ValidationConfiguration`) and by `ExceptionMappingService`, which looks a REST error up under the key `openl.error.<status>.<code>` built by `RestRuntimeException.getErrorCode()` from the literal code the exception carries. Every one of the 228 keys was checked twice with `grep -rIF` over the whole repository outside `target/` and `node_modules/`: once for the full key and once for its status-stripped code as a Java string literal. This key has neither: the literal `"project.merge.branch.protected.message"` is thrown nowhere, and its only mention is a JavaDoc sentence in `ProtectedBranchBypassService` recording that the merge endpoints *used to* answer 409 with it and now raise `ForbiddenException` or `ProtectedBranchBypassRequiredException` instead. The other 100 keys without a full-key hit are all thrown as such literals (for example `"project.merge.branch.locked.message"` in `ProjectsMergeServiceImpl`); `jakarta.validation.constraints.Size.message` is the Bean Validation default template reached from `@Size`; the two `ws.project.openapi.mode.*` keys of `messages.properties` are composed in `project.xhtml` from the `OpenAPI.Mode` enum. The `studio-ui` tests that show the sentence "because it is protected" stub a 409 response body and do not name the key; no ITEST fixture outside `target/` names it.
- **Verified:** `mvn -o clean install -Dquick -DnoPerf -T2` over the whole reactor on this head (all Java tests and the `studio-ui` vitest suite), green; `mvn validate -N` clean.
- **Kept or deferred:** every other key of the four webstudio message bundles is reached by a literal, by the `openl.error.<status>.` composition, by a Bean Validation default template, or by an EL-composed enum name; `sql-errors.properties` is keyed by the vendor `SQLException.getErrorCode()` at runtime, so none of its seven codes can be judged statically. All 46 legacy `.xhtml` pages are reached (`ui:include`, `ui:composition`, the crossroads hash router in `index.xhtml`, `web.xml`, `DefaultServlet`, `DiffController`, or a React `faces/…` link), so no page is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq8HTp7viBLS6HTTCqdDd9)_