### PR TITLE
Remove dead internal nested classes in the OpenL iterator utilities

### DIFF
--- a/DEV/org.openl.commons/src/org/openl/util/AOpenIterator.java
+++ b/DEV/org.openl.commons/src/org/openl/util/AOpenIterator.java
@@ -6,11 +6,7 @@
 
 package org.openl.util;
 
-import java.util.Iterator;
 import java.util.NoSuchElementException;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author snshor
@@ -33,31 +29,6 @@ public abstract class AOpenIterator<T> implements IOpenIterator<T> {
         @Override
         public int size() {
             return 0;
-        }
-
-    }
-
-    @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-    abstract static class IteratorWrapper<T, C> extends AOpenIterator<C> {
-        protected final Iterator<T> it;
-
-        @Override
-        public boolean hasNext() {
-            return it.hasNext();
-        }
-
-        @Override
-        public abstract C next();
-    }
-
-    static class SimpleIteratorWrapper<T> extends IteratorWrapper<T, T> {
-        SimpleIteratorWrapper(Iterator<T> it) {
-            super(it);
-        }
-
-        @Override
-        public T next() {
-            return it.next();
         }
 
     }


### PR DESCRIPTION
Messaged by Claude Routine: Dead code sweep (openl-tablets)

Daily dead-code sweep. Each commit carries exactly one change type across the whole repository, so a reviewer checks the rule once per commit. This pull request carries the single finding that survived proof in a new pass: constructor reachability over the whole reactor.

**Commits:** 1 · **Diff:** 1 file changed, 29 deletions(-)

## Remove the AOpenIterator wrappers nothing instantiates

- **Removed:** the package-private nested classes `AOpenIterator.IteratorWrapper` and `AOpenIterator.SimpleIteratorWrapper` in `DEV/org.openl.commons/src/org/openl/util/AOpenIterator.java`, together with the `java.util.Iterator` and Lombok imports they were the only users of.
- **Evidence:** a new detector was run this pass — an ASM scan over the 5155 compiled classes of the whole reactor (every module's `target/classes` and `target/test-classes`, 106 class directories) that records every constructor invocation reached through INVOKESPECIAL, a method handle, or an invokedynamic bootstrap argument, matches them against every declared constructor by owner and descriptor, and reports the ones nothing invokes. `SimpleIteratorWrapper` is the only subclass of `IteratorWrapper` and nothing constructs it, so neither class can ever have an instance. Both are package-private, so no consumer outside `org.openl.util` could subclass or instantiate them either. Both names were then searched over the whole repository with `grep -rIwn` outside `target/`, `node_modules/` and `.git/`, with `grep -ra` so that binaries are covered, and inside every tracked `.xlsx` with `unzip -p`: the only file that mentions either name is the one being edited. The scan's own index of string constants loaded by any class in the reactor contains neither name, so no reflective lookup reaches them.
- **Verified:** `mvn -o test -Dquick -DnoPerf -pl DEV/org.openl.commons` (264 tests) and then `mvn -o clean install -Dquick -DnoPerf -T2` over the whole reactor on this head, both green; `mvn validate -N` clean.
- **Kept or deferred:** the scan reported 9 uninvoked non-public constructors that take parameters and 901 that take none, and every other one is alive or not deletable. Records bound by Jackson keep their canonical constructor through reflection (`ViteAssetsBean.ViteManifestEntry` from the Vite manifest, the ITEST records read by `getForObject` and `awaitMatching`); `ClassForStringConstructorLoadingTests` is instantiated by the OpenL String-constructor datatype loading it is named after; the extra-method handler in `ServiceInterfaceMethodInterceptingTest` is built by Spring from a constructor whose parameters carry `@Autowired` and `@Value`; a private record used only as `resolveSchema(ValueHolder.class)` cannot lose its canonical constructor. Of the no-argument constructors, the private ones are the anti-instantiation idiom, the package-private ones belong overwhelmingly to JUnit test classes, and the eleven in production code are Jackson MixIns, JAXB `XmlAdapter`s, a Spring `@Component` and a Spring `@Conditional` condition, or the implicit default constructor of a utility class, which has no source line to delete. `ChoicePointLabel` in `DEV/org.openl.rules.constrainer` is deferred, not removed: its only constructor is package-private and uninvoked, so the `Constrainer`, `Failure`, `GoalOr` and `GoalStack` members typed on it always hold `null`, but the class is public API of a published artifact and removing it would change those public signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLxoHibLod7TxhzgEHu5pJ)_